### PR TITLE
Copy of Chart and Github Workflow from BanzaiCloud/charts github repo

### DIFF
--- a/.github/workflows/check-chart-migration.yaml
+++ b/.github/workflows/check-chart-migration.yaml
@@ -1,0 +1,30 @@
+name: Check Helm Chart Migration
+
+on:
+  push:
+
+jobs:
+  check-migration:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout current repository
+      uses: actions/checkout@v2
+
+    - name: Checkout banzaicloud/banzai-charts at tag cadence/0.24.1
+      uses: actions/checkout@v2
+      with:
+        repository: banzaicloud/banzai-charts
+        ref: cadence/0.24.2
+        path: banzai-charts
+
+    - name: Compare Helm Charts excluding README.md
+      run: |
+        for file in $(find banzai-charts/cadence -type f ! -name "README.md"); do
+          relative_path=${file#banzai-charts/cadence/}
+          diff "$file" "charts/cadence/$relative_path" || { echo "Difference found in $file"; exit 1; }
+        done
+
+    - name: Compare CI Pipeline
+      run: |
+        diff .github/workflows/ci.yaml banzai-charts/.github/workflows/ci.yaml || { echo "CI pipelines are not identical!"; exit 1; }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,123 @@
+name: Helm chart
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "**/[0-9]+.[0-9]+.[0-9]+"
+      - "**/[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+  pull_request:
+
+env:
+  HELM_PLUGIN_CHARTMUSEUM_PUSH_VERSION: 0.9.0
+  HELM_PUSH_REPOSITORY_NAME: chartmuseum
+  HELM_VERSION: 3.1.1
+
+jobs:
+  helm:
+    name: Helm
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add incubator https://charts.helm.sh/incubator
+          helm repo add chartmuseum https://kubernetes-charts.banzaicloud.com
+          helm repo add banzaicloud-stable http://kubernetes-charts.banzaicloud.com/branch/master
+          helm repo add rimusz https://charts.rimusz.net
+
+      - name: Update Helm repositories
+        run: |
+          helm repo update
+          helm repo list
+
+      - name: Update Helm dependencies
+        run: |
+          find -H '.' \
+            -maxdepth 2 \
+            -name 'Chart.yaml' \
+            -execdir helm dependency update \;
+
+      - name: Lint Helm charts
+        run: |
+          find -H '.' \
+            -maxdepth 2 \
+            -name 'Chart.yaml' \
+            -printf '%h\n' \
+              | xargs helm lint
+
+      - name: Set Git refname
+        id: set-git-refname
+        run: |
+          GIT_REFNAME="$(echo "${{ github.ref }}" | sed -r 's@refs/(heads|pull|tags)/@@g')"
+
+          echo "GIT_REFNAME=${GIT_REFNAME}"
+          echo "git_refname=${GIT_REFNAME}" >> $GITHUB_OUTPUT
+
+      - name: Set Helm push enabled
+        id: set-helm-push-enabled
+        run: |
+          HELM_PUSH_ENABLED=""
+          if [ "${{ github.event_name }}" == "push" ] && echo "${{ steps.set-git-refname.outputs.git_refname }}" | grep -E -q "^(chart/)?[^/]+/[0-9]+\.[0-9]+\.[0-9]+"; then
+            HELM_PUSH_ENABLED=1
+          else
+            printf >&2 "Unstable chart (%s) from %s event, chart will not be pushed" "${{ steps.set-git-refname.outputs.git_refname }}" "${{ github.event_name }}"
+          fi
+
+          echo "HELM_PUSH_ENABLED=${HELM_PUSH_ENABLED}"
+          echo "helm_push_enabled=${HELM_PUSH_ENABLED}" >> $GITHUB_OUTPUT
+
+      - if: ${{ steps.set-helm-push-enabled.outputs.helm_push_enabled == 1 }}
+        name: Set chart name
+        id: set-chart-name
+        run: |
+          CHART_NAME="$(echo "${{ steps.set-git-refname.outputs.git_refname }}}" | awk -F '/' '{print $(NF-1)}')"
+
+          echo "CHART_NAME=${CHART_NAME}"
+          echo "chart_name=${CHART_NAME}" >> $GITHUB_OUTPUT
+
+      - if: ${{ steps.set-helm-push-enabled.outputs.helm_push_enabled == 1 }}
+        name: Package Helm chart
+        id: package-chart
+        run: |
+          HELM_PACKAGE_OUTPUT=$(helm package "${{ github.workspace }}/${{ steps.set-chart-name.outputs.chart_name }}") || exit 1
+          HELM_PACKAGE_PATH="${HELM_PACKAGE_OUTPUT##"Successfully packaged chart and saved it to: "}"
+
+          echo "HELM_PACKAGE_PATH=${HELM_PACKAGE_PATH}"
+          echo "helm_package_path=${HELM_PACKAGE_PATH}" >> $GITHUB_OUTPUT
+
+      - if: ${{ steps.set-helm-push-enabled.outputs.helm_push_enabled == 1 }}
+        name: Check Helm chart version in repository
+        run: |
+          CHART_PATH="${{ github.workspace }}/${{ steps.set-chart-name.outputs.chart_name }}"
+          EXPECTED_CHART_VERSION="$(echo "${{ steps.set-git-refname.outputs.git_refname }}" | awk -F '/' '{print $NF}')" || exit 1
+          ACTUAL_CHART_VERSION="$(awk '/version: [0-9]+\.[0-9]+\.[0-9]+/ {print $2}' "${CHART_PATH}/Chart.yaml")" || exit 1
+
+          if [ "${EXPECTED_CHART_VERSION}" != "${ACTUAL_CHART_VERSION}" ]; then
+            printf >&2 "chart version mismatches, name: %s, expected version (from tag): %s, actual version (from chart): %s" "${{ steps.set-chart-name.outputs.chart_name }}" "${EXPECTED_CHART_VERSION}" "${ACTUAL_CHART_VERSION}"
+            exit 1
+          fi
+
+          if helm search repo "${{ env.HELM_PUSH_REPOSITORY_NAME }}/${{ steps.set-chart-name.outputs.chart_name }}" --version "${ACTUAL_CHART_VERSION}" --output json | jq --exit-status 'length > 0'; then
+              printf >&2 "chart version already exists in the repository, repository: %s, name: %s, version: %s" "${{ env.HELM_PUSH_REPOSITORY_NAME }}" "${{ steps.set-chart-name.outputs.chart_name }}" "${ACTUAL_CHART_VERSION}"
+              exit 1
+          fi
+
+      - if: ${{ steps.set-helm-push-enabled.outputs.helm_push_enabled == 1 }}
+        name: Install Helm ChartMuseum push plugin
+        run: helm plugin install "https://github.com/chartmuseum/helm-push.git" --version "${{ env.HELM_PLUGIN_CHARTMUSEUM_PUSH_VERSION }}"
+
+      - if: ${{ steps.set-helm-push-enabled.outputs.helm_push_enabled == 1 }}
+        name: Push Helm chart
+        env:
+          HELM_REPO_PASSWORD: ${{ secrets.HELM_REPO_PASSWORD }}
+          HELM_REPO_USERNAME: ${{ secrets.HELM_REPO_USERNAME }}
+        run: helm push "${{ steps.package-chart.outputs.helm_package_path }}" "${{ env.HELM_PUSH_REPOSITORY_NAME }}"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,412 @@
-# cadence-helm-chart
-An Helm Chart for Cadence
+# Cadence
+
+[Cadence](https://cadenceworkflow.io/)  is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
+
+
+## TL;DR;
+
+```bash
+$ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
+$ helm repo update
+```
+
+
+## Introduction
+
+This chart bootstraps a [Cadence](https://github.com/uber/cadence) and a [Cadence-UI](https://github.com/uber/cadence-web) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+
+## Prerequisites
+
+- Kubernetes 1.7+ with Beta APIs enabled
+- Cadence 0.24.0+
+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release --namespace cadence banzaicloud-stable/cadence
+```
+
+> **Tip**: List all releases using `helm list`
+
+
+## Upgrading Chart
+
+```console
+# Helm
+$ helm upgrade [RELEASE_NAME] banzaicloud-stable/cadence
+```
+
+### From 0.20.x (or below) to 0.21.y (or above)
+
+Version 0.21.0 extends the configuration interface by introducing
+`clusterMetadata` settings to the `values.yaml` in a backward incompatible
+manner with existing Cadence clusters.
+
+To upgrade the Cadence deployment under **existing** Cadence clusters from
+version 0.20.x (or below) to 0.21.y (or above) you **MUST** set the existing
+cluster's configuration in the `values.yaml` file's
+`.server.config.clusterMetadata` section to be used for the upgrade.
+
+#### Example configuration for upgrading from version 0.16.x (or below)
+
+```yaml
+server:
+  # ...
+  config:
+    clusterMetadata:
+      enableGlobalDomain: true
+      maximumClusterCount: 10
+      masterClusterName: "active"
+      currentClusterName: "active"
+      clusterInformation:
+        - name: active
+          enabled: true
+```
+
+#### Example configuration for upgrading from version 0.17.x
+
+```yaml
+server:
+  # ...
+  config:
+    clusterMetadata:
+      enableGlobalDomain: true
+      maximumClusterCount: 10
+      masterClusterName: "master"
+      currentClusterName: "master"
+      clusterInformation:
+        - name: master
+          enabled: true
+```
+
+#### Example configuration for upgrading from 0.18.x (or above), single Cadence cluster
+
+```yaml
+server:
+  # ...
+  config:
+    clusterMetadata:
+      enableGlobalDomain: true
+      maximumClusterCount: 10
+      masterClusterName: "primary"
+      currentClusterName: "primary"
+      clusterInformation:
+        - name: primary
+          enabled: true
+```
+
+#### Example configuration for upgrading from 0.18.x (or above), multiple Cadence clusters
+
+```yaml
+server:
+  # ...
+  config:
+    clusterMetadata:
+      enableGlobalDomain: true
+      maximumClusterCount: 10
+      masterClusterName: "primary"
+      currentClusterName: "primary" # "secondary" # Note: use the name of the Cadence cluster you are using on the cluster/namespace/release you are upgrading.
+      clusterInformation:
+        - name: primary
+          enabled: true
+        - name: secondary
+          enabled: true
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+
+## Install the Chart with Cassandra
+
+The chart comes with a single node Cassandra by default (from [incubator/cassandra](https://github.com/helm/charts/tree/master/incubator/cassandra)).
+
+```bash
+$ helm install banzaicloud-stable/cadence
+```
+
+You can increase the number of Cassandra nodes if you want:
+
+```bash
+$ helm install --set cassandra.config.cluster_size=3 banzaicloud-stable/cadence
+```
+
+> **Note:** It takes a few minutes to start Cassandra. You can speed it up by using configuration from `values.dev.yaml`.
+
+
+## Configure the Chart to use existing Cassandra cluster
+
+You can configure the chart to use an existing Cassandra cluster instead of installing one.
+
+**Prerequisites:**
+
+- Running Cassandra cluster
+- Existing keyspaces for *default* and *visibility* stores
+- Existing user(s) with access to those keyspaces (if authentication is required)
+
+You can easily start your own Cassandra cluster using the same [incubator/cassandra](https://github.com/helm/charts/tree/master/incubator/cassandra) chart:
+
+```bash
+$ helm install -f values/cassandra.yaml --name cassandra incubator/cassandra
+```
+
+Wait for Cassandra to become ready:
+
+```bash
+$ kubectl wait --for=condition=Ready pod/cassandra-0 --timeout=90s
+```
+
+Create two Cassandra keyspaces:
+
+```bash
+$ kubectl exec -it cassandra-0 -- cqlsh -e "CREATE KEYSPACE cadence WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };"
+$ kubectl exec -it cassandra-0 -- cqlsh -e "CREATE KEYSPACE cadence_visibility WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };"
+```
+
+```bash
+$ helm install -f values/values.cassandra.yaml banzaicloud-stable/cadence
+```
+
+Alternatively, install the chart with manual migrations. Follow the steps in [migrations.md](migrations.md).
+
+```bash
+$ helm install -f values/values.cassandra.yaml --set schema.setup.enabled=false --set schema.update.enabled=false banzaicloud-stable/cadence
+```
+
+
+## Install the Chart with MySQL
+
+> **Note:** MySQL support is currently *beta* in Cadence.
+
+The chart can be installed with a single node MySQL (from [stable/mysql](https://github.com/helm/charts/tree/master/stable/mysql)).
+
+```bash
+$ helm install --set cassandra.enabled=false --set mysql.enabled=true --set mysql.mysqlPassword=cadence banzaicloud-stable/cadence
+```
+
+> **Note:** When installing MySQL from within the chart with automatic migrations, you **must** configure a password.
+> See the [Limitations](#limitations) section for details.
+
+
+## Configure the Chart to use existing MySQL instance
+
+You can configure the chart to use an existing MySQL instance instead of installing one.
+
+**Prerequisites:**
+
+- Running MySQL instance
+- Existing databases for *default* and *visibility* stores
+- Existing user(s) with access to those databases
+
+You can easily start your own MySQL instance using the same [stable/mysql](https://github.com/helm/charts/tree/master/stable/mysql) chart:
+
+```bash
+$ helm install -f values/mysql.yaml --name mysql stable/mysql
+```
+
+Wait for MySQL to become ready:
+
+```bash
+$ kubectl wait --for=condition=Ready pod/$(kubectl get pods -l 'app=mysql' -o jsonpath='{..metadata.name}') --timeout=90s
+```
+
+```bash
+$ helm install -f values/values.mysql.yaml banzaicloud-stable/cadence
+```
+
+Alternatively, install the chart with manual migrations. Follow the steps in [migrations.md](migrations.md).
+
+```bash
+$ helm install -f values/values.mysql.yaml --set schema.setup.enabled=false --set schema.update.enabled=false banzaicloud-stable/cadence
+```
+
+
+## Prometheus monitoring
+
+As of 0.5.8 Cadence exports Prometheus metrics. The chart supports annotating Cadence components with Prometheus annotations,
+so that Prometheus can scrape them:
+
+```bash
+$ helm install --set server.metrics.annotations.enabled=true banzaicloud-stable/cadence
+```
+
+Alternatively, you can enable ServiceMonitor when using [Prometheus Operator](https://github.com/coreos/prometheus-operator):
+
+```bash
+$ helm install --set server.metrics.serviceMonitor.enabled=true banzaicloud-stable/cadence
+```
+
+Note that you can enable monitoring for each service separately. See the configuration reference bellow.
+
+
+## Scaling Cadence
+
+Cadence server components (frontend, history, matching, worker) are executed in separate Deployments, so scaling them separately is possible.
+However you can decide to apply the same replica count to each service (just like in case of resource limits and taint/affinity settings).
+
+See the configuration reference bellow for details.
+
+
+## Recommended setup
+
+The chart is self-contained, meaning it installs everything required for running the application by default.
+It can install Cassandra (default) or MySQL,
+but it is recommended that you configure every component and run migrations manually.
+
+See [values.prod.yaml](values.prod.yaml) for details of a production setup.
+
+See [migrations.md](migrations.md) for running migrations manually.
+
+
+## Limitations
+
+In order to use the automatic migration feature, you have to manually set credentials for the chosen storage type (if there is any).
+The default Cassandra store is installed without password, but for MySQL to work you have to set `mysql.mysqlPassword` manually (if you install a storage engine from within the chart).
+
+The reason behind this limitation is that migrations are executed as helm hooks, which needs the credentials before MySQL is even started.
+
+
+## Port forwarding to Cadence frontend
+
+As of version 0.5.1 of this chart service (frontend, history, matching, worker) pods use the [pod IP as bind address](https://github.com/banzaicloud/banzai-charts/pull/997).
+
+This is a limitation of how Cadence cluster membership works and is required for scaling Cadence components.
+
+Unfortunately, this change caused `kubectl port-forward` directly to Cadence pods to stop working.
+
+If you need to port forward to any of the components (eg. to create a domain), you can use a `socat` sidecar container
+(for example by installing and configuring the [stable/socat-tunneller](https://hub.helm.sh/charts/stable/socat-tunneller) chart):
+
+```bash
+helm install stable/socat-tunneller --name cadence-frontend-tunnel --set tunnel.host=cadence-frontend --set tunnel.port=7933 --set nameOverride=cadence-frontend-tunnel
+```
+
+Then you can port-forward to this tunnel:
+
+```bash
+kubectl port-forward svc/cadence-frontend-tunnel 7933:7933
+```
+
+and create a domain:
+
+```bash
+docker run --rm ubercadence/cli:master --address host.docker.internal:7933 --domain samples-domain domain register --global_domain false
+```
+
+## Metrics
+
+Note: from chart version 0.19.0, the metrics collection services (Prometheus,
+StatsD) are mutually exclusive - only one of those can be enabled at the same
+time based on the values configuration. The default configuration enables
+Prometheus.
+
+If you want to enable StatsD (and disable Prometheus), you may edit the global
+metrics configuration values accordingly. If you want to use them in a mixed
+fashion, make sure to disable both in the global metrics configuration values
+and enable the desired one in the service-specific configuration values (this is
+required, because global configurations take precedence over service-specific
+configurations).
+
+## Configuration
+
+The following table lists the configurable parameters of the chart and their default values.
+Global options overridable per service are marked with an asterisk.
+
+| Parameter                                         | Description                                           | Default               |
+|---------------------------------------------------|-------------------------------------------------------|-----------------------|
+| `nameOverride`                                    | Override name of the application                      | ``                    |
+| `fullnameOverride`                                | Override full name of the application                 | ``                    |
+| `server.image.repository`                         | Server image repository                               | `ubercadence/server`  |
+| `server.image.tag`                                | Server image tag                                      | `0.24.0`              |
+| `server.image.pullPolicy`                         | Server image pull policy                              | `IfNotPresent`        |
+| `server.replicaCount`*                            | Server replica count                                  | `1`                   |
+| `server.metrics.annotations.enabled`*             | Annotate pods with Prometheus annotations             | `false`               |
+| `server.metrics.serviceMonitor.enabled`*          | Enable Prometheus ServiceMonitor                      | `false`               |
+| `server.metrics.prometheus.timerType`*            | Prometheus timer type                                 | `histogram`           |
+| `server.metrics.statsd.hostPort`*                 | Statsd daemon host and port                           | ``                    |
+| `server.podAnnotations`*                          | Server pod annotations                                | `{}`                  |
+| `server.podSecurityContext`*                      | Server pod security context                           | `{}`                  |
+| `server.securityContext`*                         | Server security context                               | `{}`                  |
+| `server.resources`*                               | Server CPU/Memory resource requests/limits            | `{}`                  |
+| `server.nodeSelector`*                            | Node labels for pod assignment                        | `{}`                  |
+| `server.tolerations`*                             | Toleration labels for pod assignment                  | `[]`                  |
+| `server.affinity`*                                | Affinity settings for pod assignment                  | `{}`                  |
+| `server.config.logLevel`                          | Server log level                                      | `debug,info`          |
+| `server.config.numHistoryShards`                  | Number of history shards                              | `1000`                |
+| `server.config.persistence.[store].driver`        | Connection driver                                     | `cassandra`           |
+| `server.config.persistence.[store].cassandra`     | Cassandra connection details (see `values.yaml`)      | `{}`                  |
+| `server.config.persistence.[store].sql`           | SQL connection details (see `values.yaml`)            | `{}`                  |
+| `server.[service].service.type`                   | `[service]` service type                              | `ClusterIP`           |
+| `server.[service].service.port`                   | `[service]` service port                              | `7933/7934/7935/7939` |
+| `server.[service].service.annotations`            | `[service]` service annotations                       | `{}`                  |
+| `server.[service].metrics.annotations.enabled`    | Annotate `[service]` pods with Prometheus annotations | ``                    |
+| `server.[service].metrics.serviceMonitor.enabled` | Enable Prometheus ServiceMonitor for `[service]`      | ``                    |
+| `server.[service].metrics.prometheus.timerType`   | `[service]` Prometheus timer type                     | ``                    |
+| `server.[service].metrics.statsd.hostPort`        | `[service]` Statsd daemon host and port               | ``                    |
+| `server.[service].podAnnotations`                 | `[service]` pod annotations                           | `{}`                  |
+| `server.[service].podSecurityContext`             | `[service]` pod security context                      | `{}`                  |
+| `server.[service].securityContext`                | `[service]` security context                          | `{}`                  |
+| `server.[service].resources`                      | `[service]` CPU/Memory resource requests/limits       | `{}`                  |
+| `server.[service].nodeSelector`                   | `[service]` Node labels for pod assignment            | `{}`                  |
+| `server.[service].tolerations`                    | `[service]` Toleration labels for pod assignment      | `[]`                  |
+| `server.[service].affinity`                       | `[service]` Affinity settings for pod assignment      | `{}`                  |
+| `server.frontend.service.nodePort`                | frontend service nodePort, if service type is NodePort| ``                    |
+| `web.enabled`                                     | Enable WebUI service                                  | `true`                |
+| `web.replicaCount`                                | Number of WebUI service Replicas                      | `1`                   |
+| `web.image.repository`                            | WebUI image repository                                | `ubercadence/web`     |
+| `web.image.tag`                                   | WebUI image tag                                       | `3.32.0`              |
+| `web.image.pullPolicy`                            | WebUI image pull policy                               | `IfNotPresent`        |
+| `web.service.annotations`                         | WebUI service annotations                             | `{}`                  |
+| `web.service.type`                                | WebUI service type                                    | `ClusterIP`           |
+| `web.service.port`                                | WebUI service port                                    | `80`                  |
+| `web.service.nodePort`                            | WebUI service nodePort, if service type is NodePort   | ``                    |
+| `web.ingress.enabled`                             | Enable WebUI Ingress                                  | `false`               |
+| `web.ingress.annotations`                         | WebUI Ingress annotations                             | `{}`                  |
+| `web.ingress.hosts`                               | WebUI Ingress hosts                                   | `/`                   |
+| `web.ingress.tls`                                 | WebUI Ingress tls config                              | `[]`                  |
+| `web.podSecurityContext`                          | WebUI pod security context                            | `{}`                  |
+| `web.securityContext`                             | WebUI security context                                | `{}`                  |
+| `web.resources`                                   | WebUI CPU/Memory resource requests/limits             | `{}`                  |
+| `web.nodeSelector`                                | Node labels for pod assignment                        | `{}`                  |
+| `web.tolerations`                                 | Toleration labels for pod assignment                  | `[]`                  |
+| `web.affinity`                                    | Affinity settings for pod assignment                  | `{}`                  |
+| `schema.setup.enabled`                            | Create database or keyspace                           | `true`                |
+| `schema.setup.backoffLimit`                       | Create database job back off limit                    | `100`                 |
+| `schema.update.enabled`                           | Update schema                                         | `true`                |
+| `schema.update.backoffLimit`                      | Update schema job back off limit                      | `100`                 |
+| `cassandra.enabled`                               | Install Cassandra cluster                             | `true`                |
+| `cassandra.config.cluster_size`                   | Cassandra cluster node number                         | `1`                   |
+| `mysql.enabled`                                   | Install MySQL                                         | `false`               |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```bash
+$ helm install --name my-release --set server.image.tag=0.7.1 banzaicloud-stable/cadence
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example:
+
+```bash
+$ helm install --name my-release --values values.yaml banzaicloud-stable/cadence
+```
+
+## Contributing
+
+### Chart upgrade
+
+For contributions involving an upgrade to the Cadence server version or
+modifying the chart and subsequently releasing new chart versions, please refer
+to the [Cadence chart upgrade documentation](docs/cadence_chart_upgrade.md)

--- a/charts/cadence/.gitignore
+++ b/charts/cadence/.gitignore
@@ -1,0 +1,1 @@
+values.local.yaml

--- a/charts/cadence/.helmignore
+++ b/charts/cadence/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cadence/Chart.yaml
+++ b/charts/cadence/Chart.yaml
@@ -1,0 +1,16 @@
+name: cadence
+version: 0.24.2
+appVersion: 0.24.0
+description: Cadence is a distributed, scalable, durable, and highly available orchestration engine to execute asynchronous long-running business logic in a scalable and resilient way.
+icon: https://raw.githubusercontent.com/uber/cadence-web/master/client/assets/logo.svg
+apiVersion: v1
+home: https://cadenceworkflow.io/
+engine: gotpl
+sources:
+  - https://github.com/uber/cadence
+keywords:
+  - cadence
+  - workflow
+maintainers:
+  - name: Banzai Cloud
+    email: info@banzaicloud.com

--- a/charts/cadence/docs/chart_upgrade.md
+++ b/charts/cadence/docs/chart_upgrade.md
@@ -1,0 +1,424 @@
+# Cadence chart upgrade guide
+
+## Table of contents
+
+- [I. General strategies](#I.-General-strategies)
+- [II. Gather the upstream changes (if applicable)](#II.-Gather-the-upstream-changes-(if-applicable))
+- [III. Determine the new chart version](#III.-Determine-the-new-chart-version)
+- [IV. Change the chart](#IV.-Change-the-chart)
+- [V. Test the changes](#V.-Test-the-changes)
+- [VI. Integrate the changes and release the new chart
+  version](#VI.-Integrate-the-changes-and-release-the-new-chart-version)
+
+## I. General strategies
+
+- We aim to provide charts supporting the latest available Cadence server
+  version, down to the patch semantic part.
+
+- We also intend to provide charts supporting all minor versions available
+  between the latest **chart supported** server version and the latest
+  **available** server version.
+
+  This means gradual chart releases - by latest patch of any minor version in
+  between - when multiple new server minor versions are **available** compared
+  to the latest **chart supported** server version.
+
+- If there is both
+
+   - an available server version with no supporting chart yet, and
+   - an independent chart change to be done not related to the upstream components,
+
+  at the same time, please incorporate these changes into two different chart
+  version releases as a safety measure.
+
+  Available server versions **SHOULD** take precedence unless the chart change
+  is aiming to fix a serious issue with the general usability of the chart.
+
+_There can be occasional, reasonable exceptions to these general rules, when
+necessary due to circumstances._
+
+## II. Gather the upstream changes (if applicable)
+
+Note: for chart-only changes not involving any changes in upstream references
+(for example changing chart default values, but not changing server version),
+section II. should be skipped.
+
+1. Check the available [Cadence server
+   tags](https://github.com/uber/cadence/tags).
+
+   If there is a **server version** to upgrade to, pick the latest available
+   patch version of the chosen minor version.
+
+   **Reminder**: according to the general strategy, in case multiple minor or
+   major **server versions** had been released since the last **chart version**,
+   please upgrade gradually, by the latest patch version of each minor version
+   between the latest **chart supported** server version and the latest
+   **available** server version.
+
+2. Note down any potential minor or major (breaking) change between the last
+   **chart supported** server version and the chosen next server version.
+   Breaking changes are usually listed as notes or breaking changes at the
+   upstream tag description.
+
+3. Go through the changes (consider PR- or commit-wise) and look for changes to
+   the chart/input interface and output/behavior (and also keep an eye out for
+   undocumented minor/major changes). Keep a reference of anything that might
+   require a chart value change (new configuration options, changed defaults,
+   etc.).
+
+   This can be overwhelming at first, but the main focus should be on the public
+   API's libraries and binaries (and the public interface of those) with an
+   emphasis on the static configuration.
+
+4. Check the available [Cadence web
+   tags](https://github.com/uber/cadence-web/tags).
+
+   If there is a **web version** to upgrade to, pick the latest
+   available patch version of the chosen minor version.
+
+5. Note down any potential major (breaking) change between the last **chart
+   supported** web version and the chosen next web version. Breaking
+   changes are usually listed as notes or breaking changes at the upstream tag
+   description.
+
+6. Make sure the selected **web version** is compatible with the chosen **server
+   version** (the latter takes precedence when determining the baseline).
+
+## III. Determine the new chart version
+
+[Note: major version 0.Minor.Patch may contain breaking changes in any version
+change.](https://semver.org/#spec-item-4) However it is general practice to
+reserve patch versions for patch changes only and use the minor versions for
+breaking changes of major version 0.Minor.Patch.
+
+1. From the gathered server changes, form a short summary of the chart related
+   minor and major (breaking) changes.
+
+2. Determine the new **chart version**.
+
+   a, **In case of a chart-only change (no upstream reference change)**,
+   determine the necessary **chart version change** based on the relation of the
+   change to the chart's public interface according to [semantic versioning
+   rules](https://semver.org/spec/v2.0.0.html).
+
+   b, **In case of a server version upgrade**, use the **server version change**
+   (patch, minor or major) and apply the same kind of semantic version change to
+   the last **chart version** to obtain the base of the new **chart version**.
+   If stronger semantic changes are implied to the chart than to the **server
+   version**, use the chart change's semantic scope (e.g. major - breaking -
+   change on the chart's public interface takes precedence over a minor server
+   version change and so on).
+
+   **The chart and server versions are not kept in sync** as of now, but they do
+   reflect the scope of the strongest semantic version change between two
+   versions.
+
+## IV. Change the chart
+
+1. Check out a new branch from the latest remote HEAD of the default branch.
+
+2. In case of changing the server version:
+
+   1. update the required version at the [`Prerequisites` section of the
+      `cadence/README.md`](../README.md#Prerequisites)'s to the new **server
+      version**,
+
+   2. Also update the default value of the [`Configuration / server.image.tag`
+      and optionally the `Configuration / web.image.tag` parameters in the
+      `cadence/README.md`](../README.md#Configuration) to the new **server
+      version** and **web version** respectively,
+
+   3. update the chart's default application version at the [`appVersion` field
+      in the `cadence/Chart.yaml`](../Chart.yaml)'s to the new **server
+      version**,
+
+   4. update the image tag version at the [`server.image.tag`  and optionally
+      the `web.image.tag` fields in the
+      `cadence/values.yaml`](../values.yaml)'s, to the new **server version**
+      and **web version** respectively.
+
+3. Update the chart's version at the [`version` field in the
+   `cadence/Chart.yaml`](../Chart.yaml)'s to the newly determined **chart
+   version**.
+
+4. **If there are any minor or major (breaking) changes affecting the chart,
+   update the chart files accordingly to incorporate those changes.** Make sure
+   these updates to the chart are collected and ready to be listed for
+   reference.
+
+## V. Test the changes
+
+Testing can be done in any environment utilizing the main features of the
+Cadence chart, server and client.
+
+Optionally, you may use a [Banzai Cloud
+Pipeline](https://github.com/banzaicloud/pipeline) Kind cluster instance via the
+[banzai CLI](https://github.com/banzaicloud/banzai-cli) to test the changes. You
+**MUST** have an account at a supported cloud provider in order to use this
+method.
+
+1. Choose an unused Pipeline workspace name, or reuse a previous workspace name
+   (for example `cadence-chart-upgrade`) and export the name and the workspace
+   paths derived from it.
+
+   ```shell
+   BANZAI_INSTALLER_WORKSPACE_NAME="cadence-chart-upgrade" && echo "BANZAI_INSTALLER_WORKSPACE_NAME=${BANZAI_INSTALLER_WORKSPACE_NAME}"
+   BANZAI_INSTALLER_WORKSPACE="${HOME}/.banzai/pipeline/${BANZAI_INSTALLER_WORKSPACE_NAME}" && echo "BANZAI_INSTALLER_WORKSPACE=${BANZAI_INSTALLER_WORKSPACE}"
+   ```
+
+2. **If you have no Pipeline control plane workspace set up for testing**
+   (otherwise you may use your existing workspace), you can initialize one the
+   following way:
+
+   a, Generate the initial workspace configuration.
+
+   ```shell
+   banzai pipeline init --provider kind --workspace ${BANZAI_INSTALLER_WORKSPACE}
+   ```
+   (for the following steps you **MAY** use the [yq CLI Yaml
+   processor](https://github.com/mikefarah/yq).)
+
+   b, Save the workspace values YAML file's location for reuse.
+
+   ```shell
+   export BANZAI_INSTALLER_WORKSPACE_VALUES="${BANZAI_INSTALLER_WORKSPACE}/values.yaml" && echo "BANZAI_INSTALLER_WORKSPACE_VALUES=${BANZAI_INSTALLER_WORKSPACE_VALUES}"
+   ```
+
+   b, You **MUST** set up a
+   [CloudInfo](https://github.com/banzaicloud/cloudinfo/) instance to be used
+   for test cluster creation. Currently there is no publicly available hosted
+   instance, but you **MAY** host one yourself.
+
+   ```shell
+   yq eval ".pipeline.configuration.cloudinfo.endpoint = \"${YOUR_CLOUDINFO_INSTANCE_ENDPOINT}\"" "${BANZAI_INSTALLER_WORKSPACE_VALUES}" --inplace
+   ```
+
+   c, You **MUST** enable the Cadence web frontend in case you need it.
+
+   ```shell
+   yq eval ".cadence.web.enabled = true" "${BANZAI_INSTALLER_WORKSPACE_VALUES}" --inplace
+   ```
+
+   d, You **MAY** change the workspace `values.yaml` 's ` installer.image` value
+   to `banzaicloud/pipeline-installer:latest` so it always uses the latest
+   available tag, automatically keeping it up to date.
+
+   ```shell
+   yq eval ".installer.image = \"$(yq eval .installer.image ${BANZAI_INSTALLER_WORKSPACE_VALUES} | sed -E 's/banzaicloud\/pipeline\-installer\@sha256\:.+/banzaicloud\/pipeline\-installer\:latest/g')\"" "${BANZAI_INSTALLER_WORKSPACE_VALUES}" --inplace
+   ```
+
+   e, You **MAY** also change the Kind cluster name to a unique one to avoid
+   name clashing.
+
+   ```shell
+   yq eval ".providerConfig.cluster_name = \"${BANZAI_INSTALLER_WORKSPACE_NAME}-control-plane\"" "${BANZAI_INSTALLER_WORKSPACE_VALUES}" --inplace
+   ```
+
+   After these modifications, the `values.yaml` file in your workspace **MAY**
+   look like the following:
+
+   ```shell
+   cadence:
+      web:
+         enabled: true
+   defaultStorageBackend: mysql
+   externalHost: default.localhost.banzaicloud.io
+   ingressHostPort: true
+   installer:
+      image: banzaicloud/pipeline-installer:latest
+   provider: kind
+   tlsInsecure: true
+   uuid: ${UUID}
+   providerConfig:
+      cluster_name: cadence-chart-upgrade-control-plane
+   pipeline:
+   configuration:
+      cloudinfo:
+         endpoint: ${URL}
+   ```
+
+3. Set up the Kind control plane cluster.
+
+   ```shell
+   banzai pipeline up --workspace ${BANZAI_INSTALLER_WORKSPACE}
+   ```
+
+4. When prompted, log in to the CLI using the offered browser method. You should
+   use the generated static credentials written to the output of the CLI
+   command.
+
+5. Use the Kind cluster's Kubernetes configuration.
+
+   ```shell
+   BANZAI_INSTALLER_WORKSPACE_KUBECONFIG="${BANZAI_INSTALLER_WORKSPACE}/.kube/config" && echo "BANZAI_INSTALLER_WORKSPACE_KUBECONFIG=${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}"
+   ```
+
+6. Check and wait for the cadence pods (frontend, history, matching, worker) to
+   be running.
+
+   ```shell
+   watch kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud get pods --selector "app.kubernetes.io/instance=cadence"
+   ```
+
+7. Check the currently deployed Cadence **server version**.
+
+   ```shell
+   kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud get pods --selector "app.kubernetes.io/instance=cadence" --output yaml | grep -E "^(\s+image: [^ ]+)|(\s+helm.sh/chart: [^ ]+)$"
+   ```
+
+   It is expected to output something like `      image:
+   ubercadence/server:Major.Minor.Patch`.
+
+8. If the deployed server version is not the [latest chart supported server
+   version](https://github.com/banzaicloud/banzai-charts/blob/master/cadence/Chart.yaml#L3),
+   deploy the latest chart.
+
+   ```shell
+   helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
+   helm repo update
+   helm upgrade --debug --install --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud cadence banzaicloud-stable/cadence
+   ```
+
+9. If the upgrade finishes successfully, wait for the old pods being terminated
+   and for the new ones transferring to running state.
+
+   ```shell
+   watch kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud get pods --selector "app.kubernetes.io/instance=cadence"
+   ```
+
+10. Check the Cadence server version to be the latest chart supported one.
+
+    ```shell
+    kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud get pods --selector "app.kubernetes.io/instance=cadence" --output yaml | grep -E "^(\s+image: [^ ]+)|(\s+helm.sh/chart: [^ ]+)$"
+    ```
+
+11. Create a cluster.
+
+   ```yaml
+   # banzai_cluster_create.yaml
+   name: cluster-name
+   location: eu-central-1
+   cloud: amazon
+   secretName: banzai-secret-name
+   properties:
+   eks:
+      version: "1.18"
+      nodePools:
+         pool1:
+            autoscaling: true
+            count: 5
+            instanceType: t3a.small
+            maxCount: 10
+            minCount: 2
+   ```
+
+    ```shell
+    AWS_PROFILE=profile && echo "AWS_PROFILE=${AWS_PROFILE}"
+    BANZAI_CLUSTER_CREATE_YAML=banzai_cluster_create.yaml && echo "BANZAI_CLUSTER_CREATE_YAML=${BANZAI_CLUSTER_CREATE_YAML}"
+    BANZAI_SECRET_NAME=banzai-secret-name && echo "BANZAI_SECRET_NAME=${BANZAI_SECRET_NAME}"
+
+    AWS_PROFILE=${AWS_PROFILE} banzai secret create --magic --type "amazon" --validate true --tag "" --name "${BANZAI_SECRET_NAME}"
+    banzai cluster create --name "${BANZAI_INSTALLER_WORKSPACE_NAME}-pre" --file "${BANZAI_CLUSTER_CREATE_YAML}"
+    watch banzai cluster list
+    ```
+
+12. Using your local branch, upgrade the Cadence Helm chart of the control plane
+    to the new server version you are testing.
+
+    ```shell
+    helm dep build cadence # where ${PWD} == local banzaicloud/banzai-charts repository.
+    helm upgrade --debug --install --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud cadence ./cadence
+    ```
+
+13. If the upgrade finishes successfully, wait for the old pods being terminated
+    and for the new ones transferring to running state.
+
+    ```shell
+    watch kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud get pods --selector "app.kubernetes.io/instance=cadence"
+    ```
+
+14. Check the Cadence server version to be the new one.
+
+    ```shell
+    kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud get pods --selector "app.kubernetes.io/instance=cadence" --output yaml | grep -E "^(\s+image: [^ ]+)|(\s+helm.sh/chart: [^ ]+)$"
+    ```
+
+15. Start creating a new cluster
+
+    ```shell
+    banzai cluster create --name "${BANZAI_INSTALLER_WORKSPACE_NAME}-post" --file "${BANZAI_CLUSTER_CREATE_YAML}"
+    ```
+
+16. Upgrade the previously existing cluster's node pool. Wait for it to finish
+    and observe its successful completion.
+
+    ```shell
+    BANZAI_CLUSTER_NODEPOOL_UPGRADE_YAML=banzai_cluster_node_pool_upgrade.yaml && echo "BANZAI_CLUSTER_NODEPOOL_UPGRADE_YAML=${BANZAI_CLUSTER_NODEPOOL_UPGRADE_YAML}"
+
+    banzai cluster nodepool list --cluster-name "${BANZAI_INSTALLER_WORKSPACE_NAME}-pre"
+    banzai cluster nodepool upgrade pool1 --cluster-name "${BANZAI_INSTALLER_WORKSPACE_NAME}-pre" --file "${BANZAI_CLUSTER_NODEPOOL_UPGRADE_YAML}"
+    banzai cluster nodepool list --cluster-name "${BANZAI_INSTALLER_WORKSPACE_NAME}-pre"
+    ```
+
+17. Delete the old cluster
+
+    ```shell
+    banzai cluster delete --cluster-name "${BANZAI_INSTALLER_WORKSPACE_NAME}-pre"
+    ```
+
+18. Wait for the old cluster to be deleted and the new to be created.
+
+    ```shell
+    watch banzai cluster list
+    ```
+
+19. When the new cluster is created perform a node pool upgrade on it, wait for
+    its completion and observe its success.
+
+    ```shell
+    banzai cluster nodepool list --cluster-name "${BANZAI_INSTALLER_WORKSPACE_NAME}-post"
+    banzai cluster nodepool upgrade pool1 --cluster-name "${BANZAI_INSTALLER_WORKSPACE_NAME}-post" --file "${BANZAI_CLUSTER_NODEPOOL_UPGRADE_YAML}"
+    banzai cluster nodepool list --cluster-name "${BANZAI_INSTALLER_WORKSPACE_NAME}-post"
+    ```
+
+20. Delete the new cluster and wait for it to be deleted.
+
+    ```shell
+    banzai cluster delete --cluster-name "${BANZAI_INSTALLER_WORKSPACE_NAME}-post"
+    watch banzai cluster list
+    ```
+
+21. If you want to check the Cadence web frontend you **MUST** port forward the
+    pod's port locally.
+
+    ```shell
+    KUBERNETES_POD_NAME_CADENCE_WEB="$(kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud get pod --selector "app.kubernetes.io/instance=cadence,app.kubernetes.io/component=web" -o name)" && echo "KUBERNETES_POD_NAME_CADENCE_WEB=${KUBERNETES_POD_NAME_CADENCE_WEB}"
+    kubectl --kubeconfig "${BANZAI_INSTALLER_WORKSPACE_KUBECONFIG}" --namespace banzaicloud port-forward "${KUBERNETES_POD_NAME_CADENCE_WEB}" 8088:8088
+    ```
+
+    Then as long as the port forwarding is active, you can view the Cadence web
+    at http://localhost:8088.
+
+22. Tear down the Kind control plane cluster.
+
+    ```shell
+    banzai pipeline down --workspace ${BANZAI_INSTALLER_WORKSPACE}
+    ```
+
+## VI. Integrate the changes and release the new chart version
+
+1. Commit your changes and open a PR to the default branch. Fill the description
+   with the relevant information, especially regarding minor and major changes.
+   Also regarding minor/major server side changes it is useful to notify not
+   just chart maintainers but also at least one of the server development team
+   to take a look on the changes, see previous PRs for example.
+
+2. Merge the PR.
+
+3. Check out the default branch, fetch the remote and reset the local default
+   branch to the latest remote HEAD.
+
+4. Tag the HEAD commit for the new Cadence chart with the tag schema
+   `cadence/Major.Minor.Patch`, check it to point to the correct commit and have
+   the expected description (highlighting breaking changes), then push it to the
+   remote. You **MAY** draft a GitHub release from the new tag.

--- a/charts/cadence/migrations.md
+++ b/charts/cadence/migrations.md
@@ -1,0 +1,92 @@
+# Running migrations for Cadence
+
+As of version 0.7.1 the production Cadence image does not automatically run migrations.
+While the helm chart provides a way to automatically run them,
+it's recommended to run them manually before installing/upgrading Cadence.
+
+This guide contains commands to run migrations on Cassandra or MySQL.
+
+The first step is to start a new shell in a Cadence container:
+
+```bash
+export CADENCE_VERSION=0.7.1
+docker run --rm -it ubercadence/server:${CADENCE_VERSION} bash
+```
+
+
+## Cassandra
+
+Set up environment variables:
+
+```bash
+export CASSANDRA_HOST=docker.for.mac.host.internal
+export CASSANDRA_DB_PORT=9042
+# Optionally:
+# export CASSANDRA_USER=
+# export CASSANDRA_PASSWORD=
+export CADENCE_KEYSPACE=cadence
+export VISIBILITY_KEYSPACE=cadence_visibility
+```
+
+
+### Create keyspaces
+
+```bash
+cadence-cassandra-tool create -k ${CADENCE_KEYSPACE}
+cadence-cassandra-tool create -k ${VISIBILITY_KEYSPACE}
+```
+
+### Set up schema for the first time
+
+```bash
+CASSANDRA_KEYSPACE=${CADENCE_KEYSPACE} cadence-cassandra-tool setup-schema -v 0.0
+CASSANDRA_KEYSPACE=${VISIBILITY_KEYSPACE} cadence-cassandra-tool setup-schema -v 0.0
+```
+
+
+### Update schema
+
+```bash
+CASSANDRA_KEYSPACE=${CADENCE_KEYSPACE} cadence-cassandra-tool update-schema -d /etc/cadence/schema/cassandra/cadence/versioned
+CASSANDRA_KEYSPACE=${VISIBILITY_KEYSPACE} cadence-cassandra-tool update-schema -d /etc/cadence/schema/cassandra/visibility/versioned
+```
+
+
+## MySQL
+
+Set up environment variables:
+
+```bash
+export SQL_PLUGIN=mysql
+export SQL_HOST=docker.for.mac.host.internal
+export SQL_PORT=3306
+# Optionally:
+# export SQL_USER=
+# export SQL_PASSWORD=
+export CADENCE_DATABASE=cadence
+export VISIBILITY_DATABASE=cadence_visibility
+```
+
+
+### Create databases
+
+```bash
+cadence-sql-tool create --db ${CADENCE_DATABASE}
+cadence-sql-tool create --db ${VISIBILITY_DATABASE}
+```
+
+
+### Set up schema for the first time
+
+```bash
+SQL_DATABASE=${CADENCE_DATABASE} cadence-sql-tool setup-schema -v 0.0
+SQL_DATABASE=${VISIBILITY_DATABASE} cadence-sql-tool setup-schema -v 0.0
+```
+
+
+### Update schema
+
+```bash
+SQL_DATABASE=${CADENCE_DATABASE} cadence-sql-tool update-schema -d /etc/cadence/schema/mysql/v57/cadence/versioned
+SQL_DATABASE=${VISIBILITY_DATABASE} cadence-sql-tool update-schema -d /etc/cadence/schema/mysql/v57/visibility/versioned
+```

--- a/charts/cadence/requirements.yaml
+++ b/charts/cadence/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+  - name: cassandra
+    version: ^0.13.1
+    repository: https://charts.helm.sh/incubator
+    condition: cassandra.enabled
+  - name: mysql
+    version: ^1.2.0
+    repository: https://charts.helm.sh/stable
+    condition: mysql.enabled

--- a/charts/cadence/templates/NOTES.txt
+++ b/charts/cadence/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that Cadence has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/charts/cadence/templates/_helpers.tpl
+++ b/charts/cadence/templates/_helpers.tpl
@@ -1,0 +1,305 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cadence.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cadence.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cadence.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified component name from the full app name and a component name.
+We truncate the full name at 63 - 1 (last dash) - len(component name) chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
+and we want to make sure that the component is included in the name.
+*/}}
+{{- define "cadence.componentname" -}}
+{{- $global := index . 0 -}}
+{{- $component := index . 1 | trimPrefix "-" -}}
+{{- printf "%s-%s" (include "cadence.fullname" $global | trunc (sub 62 (len $component) | int) | trimSuffix "-" ) $component | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Call nested templates.
+Source: https://stackoverflow.com/a/52024583/3027614
+*/}}
+{{- define "call-nested" }}
+{{- $dot := index . 0 }}
+{{- $subchart := index . 1 }}
+{{- $template := index . 2 }}
+{{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
+{{- end }}
+
+{{- define "cadence.frontend.internalGRPCPort" -}}
+7833
+{{- end -}}
+
+{{- define "cadence.frontend.internalPort" -}}
+7933
+{{- end -}}
+
+{{- define "cadence.history.internalGRPCPort" -}}
+7834
+{{- end -}}
+
+{{- define "cadence.history.internalPort" -}}
+7934
+{{- end -}}
+
+{{- define "cadence.matching.internalGRPCPort" -}}
+7835
+{{- end -}}
+
+{{- define "cadence.matching.internalPort" -}}
+7935
+{{- end -}}
+
+{{- define "cadence.worker.internalPort" -}}
+7939
+{{- end -}}
+
+{{- define "cadence.persistence.schema" -}}
+{{- if eq . "default" -}}
+{{- print "cadence" -}}
+{{- else -}}
+{{- print . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.driver" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.driver -}}
+{{- $storeConfig.driver -}}
+{{- else if $global.Values.cassandra.enabled -}}
+{{- print "cassandra" -}}
+{{- else if $global.Values.mysql.enabled -}}
+{{- print "sql" -}}
+{{- else -}}
+{{- required (printf "Please specify persistence driver for %s store" $store) $storeConfig.driver -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.cassandra.hosts" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.cassandra.hosts -}}
+{{- $storeConfig.cassandra.hosts | join "," -}}
+{{- else if and $global.Values.cassandra.enabled (eq (include "cadence.persistence.driver" (list $global $store)) "cassandra") -}}
+{{- include "cassandra.hosts" $global -}}
+{{- else -}}
+{{- required (printf "Please specify cassandra hosts for %s store" $store) $storeConfig.cassandra.hosts -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.cassandra.port" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.cassandra.port -}}
+{{- $storeConfig.cassandra.port -}}
+{{- else if and $global.Values.cassandra.enabled (eq (include "cadence.persistence.driver" (list $global $store)) "cassandra") -}}
+{{- $global.Values.cassandra.config.ports.cql -}}
+{{- else -}}
+{{- required (printf "Please specify cassandra port for %s store" $store) $storeConfig.cassandra.port -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.cassandra.secretName" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.cassandra.existingSecret -}}
+{{- $storeConfig.cassandra.existingSecret -}}
+{{- else if $storeConfig.cassandra.password -}}
+{{- include "cadence.componentname" (list $global (printf "%s-store" $store)) -}}
+{{- else -}}
+{{/* Cassandra password is optional, but we will create an empty secret for it */}}
+{{- include "cadence.componentname" (list $global (printf "%s-store" $store)) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.cassandra.secretKey" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if or $storeConfig.sql.existingSecret $storeConfig.sql.password -}}
+{{- print "password" -}}
+{{- else -}}
+{{/* Cassandra password is optional, but we will create an empty secret for it */}}
+{{- print "password" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.pluginName" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.pluginName -}}
+{{- $storeConfig.sql.pluginName -}}
+{{- else if $global.Values.mysql.enabled -}}
+{{- print "mysql" -}}
+{{- else -}}
+{{- required (printf "Please specify sql plugin for %s store" $store) $storeConfig.sql.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.host" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.host -}}
+{{- $storeConfig.sql.host -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.pluginName" (list $global $store)) "mysql")) -}}
+{{- include "mysql.host" $global -}}
+{{- else -}}
+{{- required (printf "Please specify sql host for %s store" $store) $storeConfig.sql.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.port" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.port -}}
+{{- $storeConfig.sql.port -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.pluginName" (list $global $store)) "mysql")) -}}
+{{- $global.Values.mysql.service.port -}}
+{{- else -}}
+{{- required (printf "Please specify sql port for %s store" $store) $storeConfig.sql.port -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.user" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.user -}}
+{{- $storeConfig.sql.user -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.pluginName" (list $global $store)) "mysql")) -}}
+{{- $global.Values.mysql.mysqlUser -}}
+{{- else -}}
+{{- required (printf "Please specify sql user for %s store" $store) $storeConfig.sql.user -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.password" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.password -}}
+{{- $storeConfig.sql.password -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.pluginName" (list $global $store)) "mysql")) -}}
+{{- if or $global.Values.schema.setup.enabled $global.Values.schema.update.enabled -}}
+{{- required "Please specify password for MySQL chart" $global.Values.mysql.mysqlPassword -}}
+{{- else -}}
+{{- $global.Values.mysql.mysqlPassword -}}
+{{- end -}}
+{{- else -}}
+{{- required (printf "Please specify sql password for %s store" $store) $storeConfig.sql.password -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.secretName" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if $storeConfig.sql.existingSecret -}}
+{{- $storeConfig.sql.existingSecret -}}
+{{- else if $storeConfig.sql.password -}}
+{{- include "cadence.componentname" (list $global (printf "%s-store" $store)) -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.pluginName" (list $global $store)) "mysql")) -}}
+{{- include "call-nested" (list $global "mysql" "mysql.secretName") -}}
+{{- else -}}
+{{- required (printf "Please specify sql password or existing secret for %s store" $store) $storeConfig.sql.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.sql.secretKey" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- $storeConfig := index $global.Values.server.config.persistence $store -}}
+{{- if or $storeConfig.sql.existingSecret $storeConfig.sql.password -}}
+{{- print "password" -}}
+{{- else if and $global.Values.mysql.enabled (and (eq (include "cadence.persistence.driver" (list $global $store)) "sql") (eq (include "cadence.persistence.sql.pluginName" (list $global $store)) "mysql")) -}}
+{{- print "mysql-password" -}}
+{{- else -}}
+{{- fail (printf "Please specify sql password or existing secret for %s store" $store) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cadence.persistence.secretName" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- include (printf "cadence.persistence.%s.secretName" (include "cadence.persistence.driver" (list $global $store))) (list $global $store) -}}
+{{- end -}}
+
+{{- define "cadence.persistence.secretKey" -}}
+{{- $global := index . 0 -}}
+{{- $store := index . 1 -}}
+{{- include (printf "cadence.persistence.%s.secretKey" (include "cadence.persistence.driver" (list $global $store))) (list $global $store) -}}
+{{- end -}}
+
+{{/*
+All Cassandra hosts.
+*/}}
+{{- define "cassandra.hosts" -}}
+{{- range $i := (until (int .Values.cassandra.config.cluster_size)) }}
+{{- $cassandraName := include "call-nested" (list $ "cassandra" "cassandra.fullname") -}}
+{{- printf "%s-%d.%s.%s.svc.cluster.local," $cassandraName $i $cassandraName $.Release.Namespace -}}
+{{- end }}
+{{- end -}}
+
+{{/*
+The first Cassandra host in the stateful set.
+*/}}
+{{- define "cassandra.host" -}}
+{{- $cassandraName := include "call-nested" (list . "cassandra" "cassandra.fullname") -}}
+{{- printf "%s-0.%s.%s.svc.cluster.local" $cassandraName $cassandraName .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+MySQL host.
+*/}}
+{{- define "mysql.host" -}}
+{{- printf "%s.%s.svc.cluster.local" (include "call-nested" (list . "mysql" "mysql.fullname")) .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+Format a string map as a query string.
+*/}}
+{{- define "to-query" }}
+{{- trimSuffix "&" (include "_to-query" .)  }}
+{{- end }}
+
+{{/*
+Format a string map as a query string.
+*/}}
+{{- define "_to-query" }}
+{{- range $key, $value := . -}}{{ $key }}={{ $value }}&{{- end -}}
+{{- end }}

--- a/charts/cadence/templates/server-configmap.yaml
+++ b/charts/cadence/templates/server-configmap.yaml
@@ -1,0 +1,197 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cadence.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+data:
+  config_template.yaml: |-
+    log:
+      stdout: true
+      level: {{ .Values.server.config.logLevel | quote }}
+      levelKey: {{ .Values.server.config.levelKey | quote }}
+
+    persistence:
+      defaultStore: default
+      visibilityStore: visibility
+      numHistoryShards: {{ .Values.server.config.numHistoryShards }}
+      datastores:
+        default:
+          {{- if eq (include "cadence.persistence.driver" (list . "default")) "cassandra" }}
+          nosql:
+            pluginName: cassandra
+            hosts: {{ include "cadence.persistence.cassandra.hosts" (list . "default") }}
+            port: {{ include "cadence.persistence.cassandra.port" (list . "default") }}
+            password: {{ `{{ .Env.CADENCE_STORE_PASSWORD }}` }}
+            {{- with (omit .Values.server.config.persistence.default.cassandra "hosts" "port" "password" "existingSecret") }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if eq (include "cadence.persistence.driver" (list . "default")) "sql" }}
+          sql:
+            pluginName: {{ include "cadence.persistence.sql.pluginName" (list . "default") }}
+            databaseName: {{ .Values.server.config.persistence.default.sql.database }}
+            connectAddr: "{{ include "cadence.persistence.sql.host" (list . "default") }}:{{ include "cadence.persistence.sql.port" (list . "default") }}"
+            connectProtocol: "tcp"
+            user: {{ include "cadence.persistence.sql.user" (list . "default") }}
+            password: {{ `{{ .Env.CADENCE_STORE_PASSWORD }}` }}
+            {{- with (omit .Values.server.config.persistence.default.sql "pluginName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+        visibility:
+          {{- if eq (include "cadence.persistence.driver" (list . "visibility")) "cassandra" }}
+          nosql:
+            pluginName: cassandra
+            hosts: {{ include "cadence.persistence.cassandra.hosts" (list . "visibility") }}
+            port: {{ include "cadence.persistence.cassandra.port" (list . "visibility") }}
+            password: {{ `{{ .Env.CADENCE_VISIBILITY_STORE_PASSWORD }}` }}
+            {{- with (omit .Values.server.config.persistence.visibility.cassandra "hosts" "port" "password" "existingSecret") }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if eq (include "cadence.persistence.driver" (list . "visibility")) "sql" }}
+          sql:
+            pluginName: {{ include "cadence.persistence.sql.pluginName" (list . "visibility") }}
+            databaseName: {{ .Values.server.config.persistence.visibility.sql.database }}
+            connectAddr: "{{ include "cadence.persistence.sql.host" (list . "visibility") }}:{{ include "cadence.persistence.sql.port" (list . "visibility") }}"
+            connectProtocol: "tcp"
+            user: {{ include "cadence.persistence.sql.user" (list . "visibility") }}
+            password: {{ `{{ .Env.CADENCE_VISIBILITY_STORE_PASSWORD }}` }}
+            {{- with (omit .Values.server.config.persistence.visibility.sql "pluginName" "host" "port" "connectAddr" "connectProtocol" "database" "databaseName" "user" "password" "existingSecret") }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+
+    ringpop:
+      name: cadence
+      bootstrapMode: dns
+      bootstrapHosts:
+        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.grpcPort | default `{{ default .Env.FRONTEND_GRPC_PORT 7833 }}` }}
+        - {{ include "cadence.componentname" (list . "frontend-headless") }}:{{ .Values.server.frontend.service.port | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
+        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.grpcPort | default `{{ default .Env.HISTORY_GRPC_PORT 7834 }}` }}
+        - {{ include "cadence.componentname" (list . "history-headless") }}:{{ .Values.server.history.service.port | default `{{ default .Env.HISTORY_PORT 7934 }}` }}
+        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.grpcPort | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
+        - {{ include "cadence.componentname" (list . "matching-headless") }}:{{ .Values.server.matching.service.port | default `{{ default .Env.MATCHING_PORT 7935 }}` }}
+        - {{ include "cadence.componentname" (list . "worker-headless") }}:{{ .Values.server.worker.service.port | default `{{ default .Env.WORKER_PORT 7939 }}` }}
+      maxJoinDuration: 30s
+
+    services:
+      frontend:
+        rpc:
+          grpcPort: {{ include "cadence.frontend.internalGRPCPort" . | default `{{ default .Env.FRONTEND_GRPC_PORT 7833 }}` }}
+          port: {{ include "cadence.frontend.internalPort" . | default `{{ default .Env.FRONTEND_PORT 7933 }}` }}
+          bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
+        metrics:
+          tags:
+            type: frontend
+        {{- if or .Values.server.metrics.prometheus .Values.server.frontend.metrics.prometheus }}
+          prometheus:
+            timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.frontend.metrics.prometheus.timerType }}
+            listenAddress: "0.0.0.0:9090"
+        {{- else if or .Values.server.metrics.statsd .Values.server.frontend.metrics.statsd }}
+          statsd:
+            hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.frontend.metrics.statsd.hostPort | quote }}
+            prefix: {{ `{{ default .Env.STATSD_FRONTEND_PREFIX "cadence.frontend" }}` }}
+        {{- end}}
+
+      history:
+        rpc:
+          grpcPort: {{ include "cadence.history.internalGRPCPort" . | default `{{ default .Env.HISTORY_GRPC_PORT 7834 }}` }}
+          port: {{ include "cadence.history.internalPort" . | default `{{ default .Env.HISTORY_PORT default 7934 }}` }}
+          bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
+        metrics:
+          tags:
+            type: history
+        {{- if or .Values.server.metrics.prometheus .Values.server.frontend.metrics.prometheus }}
+          prometheus:
+            timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.history.metrics.prometheus.timerType }}
+            listenAddress: "0.0.0.0:9090"
+        {{- else if or .Values.server.metrics.statsd .Values.server.history.metrics.statsd }}
+          statsd:
+            hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.history.metrics.statsd.hostPort | quote }}
+            prefix: {{ `{{ default .Env.STATSD_HISTORY_PREFIX "cadence.history" }}` }}
+        {{- end}}
+
+      matching:
+        rpc:
+          grpcPort: {{ include "cadence.matching.internalGRPCPort" . | default `{{ default .Env.MATCHING_GRPC_PORT 7835 }}` }}
+          port: {{ include "cadence.matching.internalPort" . | default `{{ default .Env.MATCHING_PORT 7935 }}` }}
+          bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
+        metrics:
+          tags:
+            type: matching
+        {{- if or .Values.server.metrics.prometheus .Values.server.frontend.metrics.prometheus }}
+          prometheus:
+            timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.matching.metrics.prometheus.timerType }}
+            listenAddress: "0.0.0.0:9090"
+        {{- else if or .Values.server.metrics.statsd .Values.server.matching.metrics.statsd }}
+          statsd:
+            hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.matching.metrics.statsd.hostPort | quote }}
+            prefix: {{ `{{ default .Env.STATSD_FRONTEND_PREFIX "cadence.matching" }}` }}
+        {{- end}}
+
+      worker:
+        rpc:
+          port: {{ include "cadence.worker.internalPort" . | default `{{ default .Env.WORKER_PORT 7939 }}` }}
+          bindOnIP: {{ `{{ default .Env.POD_IP "0.0.0.0" }}` }}
+        metrics:
+          tags:
+            type: worker
+        {{- if or .Values.server.metrics.prometheus .Values.server.frontend.metrics.prometheus }}
+          prometheus:
+            timerType: {{ default .Values.server.metrics.prometheus.timerType .Values.server.worker.metrics.prometheus.timerType }}
+            listenAddress: "0.0.0.0:9090"
+        {{- else if or .Values.server.metrics.statsd .Values.server.worker.metrics.statsd }}
+          statsd:
+            hostPort: {{ default .Values.server.metrics.statsd.hostPort .Values.server.worker.metrics.statsd.hostPort | quote }}
+            prefix: {{ `{{ default .Env.STATSD_WORKER_PREFIX "cadence.worker" }}` }}
+        {{- end}}
+
+    clusterGroupMetadata:
+      enableGlobalDomain: {{ .Values.server.config.clusterMetadata.enableGlobalDomain }}
+      failoverVersionIncrement: {{ .Values.server.config.clusterMetadata.maximumClusterCount }}
+      primaryClusterName: {{ .Values.server.config.clusterMetadata.masterClusterName }}
+      currentClusterName: {{ .Values.server.config.clusterMetadata.currentClusterName }}
+      clusterGroup:
+      {{- $currentClusterName := .Values.server.config.clusterMetadata.currentClusterName }}
+      {{- $currentClusterIndex := 0 }}
+      {{- $frontendComponentName := (include "cadence.componentname" (list . "frontend")) }}
+      {{- $serverFrontendServiceTransport := .Values.server.frontend.service.transport | default "grpc" }}
+      {{- $serverFrontendServicePort := (.Values.server.frontend.service.grpcPort | int) | default 7833 }}
+      {{- if eq $serverFrontendServiceTransport "tchannel" }}
+        {{- $serverFrontendServicePort = (.Values.server.frontend.service.port | int) }}
+      {{- end }}
+      {{- range $clusterIndex, $clusterInfo := .Values.server.config.clusterMetadata.clusterInformation }}
+        {{- if eq $clusterInfo.name $currentClusterName }}{{ $currentClusterIndex = $clusterIndex }}{{ end }}
+        {{ $clusterInfo.name }}:
+          enabled: {{ $clusterInfo.enabled }}
+          initialFailoverVersion: {{ $clusterIndex }}
+          rpcName: "{{ $frontendComponentName }}"
+          rpcAddress: "{{ $clusterInfo.rpcAddress | default (printf "%s%s%d" $frontendComponentName ":" $serverFrontendServicePort ) }}"
+          rpcTransport: "{{ $serverFrontendServiceTransport }}"
+      {{- end }}
+
+    dcRedirectionPolicy:
+      policy: {{ `{{ default .Env.DC_REDIRECT_POLICY "selected-apis-forwarding" }}` }}
+      toDC: ""
+
+    archival:
+      history:
+        status: "disabled"
+      visibility:
+        status: "disabled"
+
+    dynamicconfig:
+      client: filebased
+      filebased:
+        filepath: "/etc/cadence/config/dynamicconfig/config.yaml"
+        pollInterval: {{ .Values.dynamicConfig.pollInterval | default "10s" | quote }}
+
+  dynamic_config.yaml: |-
+    {{- toYaml .Values.dynamicConfig.values | nindent 12 }}

--- a/charts/cadence/templates/server-deployment.yaml
+++ b/charts/cadence/templates/server-deployment.yaml
@@ -1,0 +1,147 @@
+{{- range $service := (list "frontend" "history" "matching" "worker") }}
+{{- $serviceValues := index $.Values.server $service -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cadence.componentname" (list $ $service) }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    helm.sh/chart: {{ include "cadence.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: {{ $service }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+spec:
+  replicas: {{ default $.Values.server.replicaCount $serviceValues.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cadence.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: {{ $service }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "cadence.name" $ }}
+        helm.sh/chart: {{ include "cadence.chart" $ }}
+        app.kubernetes.io/managed-by: {{ $.Release.Service }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+        app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: {{ $service }}
+        app.kubernetes.io/part-of: {{ $.Chart.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/server-configmap.yaml") $ | sha256sum }}
+        {{- if (default $.Values.server.metrics.annotations.enabled $serviceValues.metrics.annotations.enabled) }}
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9090'
+        {{- end }}
+        {{- with (default $.Values.server.podAnnotations $serviceValues.podAnnotations) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      securityContext:
+        {{- toYaml (default $.Values.server.podSecurityContext $serviceValues.podSecurityContext) | nindent 8 }}
+      initContainers:
+        {{- if $.Values.cassandra.enabled }}
+        - name: check-cassandra-service
+          securityContext:
+            {{- toYaml (default $.Values.server.securityContext $serviceValues.securityContext) | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+        - name: check-cassandra
+          securityContext:
+            {{- toYaml (default $.Values.server.securityContext $serviceValues.securityContext) | nindent 12 }}
+          image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+        - name: check-cassandra-cadence-schema
+          securityContext:
+            {{- toYaml (default $.Values.server.securityContext $serviceValues.securityContext) | nindent 12 }}
+          image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.default.cassandra.keyspace }}$; do echo waiting for default keyspace to become ready; sleep 1; done;']
+        - name: check-cassandra-visibility-schema
+          securityContext:
+            {{- toYaml (default $.Values.server.securityContext $serviceValues.securityContext) | nindent 12 }}
+          image: "{{ $.Values.cassandra.image.repo }}:{{ $.Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ $.Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ $.Values.cassandra.config.ports.cql }} -e "SELECT keyspace_name FROM system_schema.keyspaces" | grep {{ $.Values.server.config.persistence.visibility.cassandra.keyspace }}$; do echo waiting for visibility keyspace to become ready; sleep 1; done;']
+        {{- else if $.Values.mysql.enabled  }}
+        - name: check-mysql-service
+          securityContext:
+            {{- toYaml (default $.Values.server.securityContext $serviceValues.securityContext) | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "mysql.host" $ }}; do echo waiting for mysql service; sleep 1; done;']
+        - name: check-mysql-port
+          securityContext:
+            {{- toYaml (default $.Values.server.securityContext $serviceValues.securityContext) | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until echo STATUS | nc -w 2 {{ include "mysql.host" $ }} {{ $.Values.mysql.service.port }}; do echo waiting for mysql to start; sleep 1; done;']
+        {{- else }}
+          []
+        {{- end }}
+      containers:
+        - name: {{ $.Chart.Name }}-{{ $service }}
+          securityContext:
+            {{- toYaml (default $.Values.server.securityContext $serviceValues.securityContext) | nindent 12 }}
+          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICES
+              value: {{ $service }}
+            - name: CADENCE_STORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ "default") }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ "default") }}
+            - name: CADENCE_VISIBILITY_STORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ "visibility") }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ "visibility") }}
+          ports:
+            - name: rpc
+              containerPort: {{ include (printf "cadence.%s.internalPort" $service) $ }}
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 150
+            tcpSocket:
+              port: rpc
+          readinessProbe:
+            initialDelaySeconds: 10
+            tcpSocket:
+              port: rpc
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cadence/config/config_template.yaml
+              subPath: config_template.yaml
+            - name: config
+              mountPath: /etc/cadence/config/dynamicconfig/config.yaml
+              subPath: dynamic_config.yaml
+          resources:
+            {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "cadence.fullname" $ }}
+      {{- with (default $.Values.server.nodeSelector $serviceValues.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with (default $.Values.server.affinity $serviceValues.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with (default $.Values.server.tolerations $serviceValues.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+---
+{{- end }}

--- a/charts/cadence/templates/server-job.yaml
+++ b/charts/cadence/templates/server-job.yaml
@@ -1,0 +1,338 @@
+{{- if .Values.schema.setup.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cadence.componentname" (list . "schema-setup") }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
+    "helm.sh/hook": post-install
+    {{- else }}
+    "helm.sh/hook": pre-install
+    {{- end }}
+    "helm.sh/hook-weight": "0"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.setup.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "cadence.componentname" (list . "schema-setup") }}
+      labels:
+        app.kubernetes.io/name: {{ include "cadence.name" . }}
+        helm.sh/chart: {{ include "cadence.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      restartPolicy: "OnFailure"
+      securityContext:
+        {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
+        {{- if .Values.cassandra.enabled }}
+        - name: check-cassandra-service
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+        - name: check-cassandra
+          image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ .Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+        {{- else if .Values.mysql.enabled }}
+        - name: check-mysql-service
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "mysql.host" $ }}; do echo waiting for mysql service; sleep 1; done;']
+        - name: check-mysql-port
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until echo STATUS | nc -w 2 {{ include "mysql.host" $ }} {{ .Values.mysql.service.port }}; do echo waiting for mysql to start; sleep 1; done;']
+        {{- end }}
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
+        - name: create-{{ $store }}-store
+          securityContext:
+            {{- toYaml $.Values.server.securityContext | nindent 12 }}
+          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
+          {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+          # args: ["cadence-cassandra-tool", "create", "-k", "{{ $storeConfig.cassandra.keyspace }}"]
+          args: ['sh', '-c', 'cadence-cassandra-tool create -k {{ $storeConfig.cassandra.keyspace }}']
+          {{- end }}
+          {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+          {{- if eq (include "cadence.persistence.sql.pluginName" (list $ $store)) "mysql" }}
+          # args: ["cadence-sql-tool", "create", "--db", "{{ $storeConfig.sql.database }}"]
+          args: ['sh', '-c', 'cadence-sql-tool create --db {{ $storeConfig.sql.database }}']
+          {{- end }}
+          {{- end }}
+          env:
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+            - name: CASSANDRA_HOST
+              value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
+            - name: CASSANDRA_DB_PORT
+              value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
+            {{- if $storeConfig.cassandra.protoVersion }}
+            - name: CASSANDRA_PROTOCOL_VERSION
+              value: {{ $storeConfig.cassandra.protoVersion }}
+            {{- end }}
+            - name: CASSANDRA_KEYSPACE
+              value: {{ $storeConfig.cassandra.keyspace }}
+            {{- if $storeConfig.cassandra.user }}
+            - name: CASSANDRA_USER
+              value: {{ $storeConfig.cassandra.user }}
+            {{- end }}
+            {{- if $storeConfig.cassandra.password }}
+            - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ include "cadence.persistence.sql.pluginName" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "cadence.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "cadence.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
+            - name: SQL_USER
+              value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
+            - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end }}
+            {{- with $storeConfig.sql.connectAttributes }}
+            - name: SQL_CONNECT_ATTRIBUTES
+              value: {{ include "to-query" . }}
+            {{- end }}
+            {{- end }}
+        {{- end }}
+        {{- else }}
+          []
+        {{- end }}
+      containers:
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
+        - name: {{ $store }}-schema
+          securityContext:
+            {{- toYaml $.Values.server.securityContext | nindent 12 }}
+          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
+          args: ["cadence-{{ include "cadence.persistence.driver" (list $ $store) }}-tool", "setup-schema", "-v", "0.0"]
+          env:
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+            - name: CASSANDRA_HOST
+              value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
+            - name: CASSANDRA_DB_PORT
+              value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
+            - name: CASSANDRA_KEYSPACE
+              value: {{ $storeConfig.cassandra.keyspace }}
+            {{- if $storeConfig.cassandra.user }}
+            - name: CASSANDRA_USER
+              value: {{ $storeConfig.cassandra.user }}
+            {{- end }}
+            {{- if $storeConfig.cassandra.password }}
+            - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ include "cadence.persistence.sql.pluginName" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "cadence.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "cadence.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
+            - name: SQL_USER
+              value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
+            - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end }}
+            {{- with $storeConfig.sql.connectAttributes }}
+            - name: SQL_CONNECT_ATTRIBUTES
+              value: {{ include "to-query" . }}
+            {{- end }}
+            {{- end }}
+        {{- end }}
+
+---
+{{- end }}
+{{- if .Values.schema.update.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cadence.componentname" (list . "schema-update") }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+  annotations:
+    {{- if or .Values.cassandra.enabled .Values.mysql.enabled }}
+    "helm.sh/hook": post-install,pre-upgrade
+    {{- else }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    {{- end }}
+    "helm.sh/hook-weight": "1"
+    {{- if not .Values.debug }}
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.schema.update.backoffLimit }}
+  template:
+    metadata:
+      name: {{ include "cadence.componentname" (list . "schema-update") }}
+      labels:
+        app.kubernetes.io/name: {{ include "cadence.name" . }}
+        helm.sh/chart: {{ include "cadence.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: database
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      restartPolicy: "OnFailure"
+      securityContext:
+        {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- if .Values.cassandra.enabled }}
+        - name: check-cassandra-service
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "cassandra.host" $ }}; do echo waiting for cassandra service; sleep 1; done;']
+        - name: check-cassandra
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: "{{ .Values.cassandra.image.repo }}:{{ .Values.cassandra.image.tag }}"
+          imagePullPolicy: {{ .Values.cassandra.image.pullPolicy }}
+          command: ['sh', '-c', 'until cqlsh {{ include "cassandra.host" $ }} {{ .Values.cassandra.config.ports.cql }} -e "SHOW VERSION"; do echo waiting for cassandra to start; sleep 1; done;']
+        {{- else if .Values.mysql.enabled }}
+        - name: check-mysql-service
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until nslookup {{ include "mysql.host" $ }}; do echo waiting for mysql service; sleep 1; done;']
+        - name: check-mysql-port
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: busybox
+          command: ['sh', '-c', 'until echo STATUS | nc -w 2 {{ include "mysql.host" $ }} {{ .Values.mysql.service.port }}; do echo waiting for mysql to start; sleep 1; done;']
+        {{- else }}
+          []
+        {{- end }}
+      containers:
+        {{- range $store := (list "default" "visibility") }}
+        {{- $storeConfig := index $.Values.server.config.persistence $store }}
+        - name: {{ $store }}-schema
+          securityContext:
+            {{- toYaml $.Values.server.securityContext | nindent 12 }}
+          image: "{{ $.Values.server.image.repository }}:{{ $.Values.server.image.tag }}"
+          imagePullPolicy: {{ $.Values.server.image.pullPolicy }}
+          {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+          # args: ["cadence-cassandra-tool", "update-schema", "-d", "/etc/cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned"]
+          args: ['sh', '-c', 'cadence-cassandra-tool update-schema -d /etc/cadence/schema/cassandra/{{ include "cadence.persistence.schema" $store }}/versioned']
+          {{- end }}
+          {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+          {{- if eq (include "cadence.persistence.sql.pluginName" (list $ $store)) "mysql" }}
+          # args: ["cadence-sql-tool", "update-schema", "-d", "/etc/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned"]
+          args: ['sh', '-c', 'cadence-sql-tool update-schema -d /etc/cadence/schema/mysql/v57/{{ include "cadence.persistence.schema" $store }}/versioned']
+          {{- end }}
+          {{- end }}
+          env:
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+            - name: CASSANDRA_HOST
+              value: {{ first (splitList "," (include "cadence.persistence.cassandra.hosts" (list $ $store))) }}
+            - name: CASSANDRA_DB_PORT
+              value: {{ include "cadence.persistence.cassandra.port" (list $ $store) | quote }}
+            - name: CASSANDRA_KEYSPACE
+              value: {{ $storeConfig.cassandra.keyspace }}
+            {{- if $storeConfig.cassandra.user }}
+            - name: CASSANDRA_USER
+              value: {{ $storeConfig.cassandra.user }}
+            {{- end }}
+            {{- if $storeConfig.cassandra.password }}
+            - name: CASSANDRA_PASSWORD
+              {{- if $storeConfig.cassandra.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ $storeConfig.cassandra.password }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+            - name: SQL_PLUGIN
+              value: {{ include "cadence.persistence.sql.pluginName" (list $ $store) }}
+            - name: SQL_HOST
+              value: {{ include "cadence.persistence.sql.host" (list $ $store) }}
+            - name: SQL_PORT
+              value: {{ include "cadence.persistence.sql.port" (list $ $store) | quote }}
+            - name: SQL_DATABASE
+              value: {{ $storeConfig.sql.database }}
+            - name: SQL_USER
+              value: {{ include "cadence.persistence.sql.user" (list $ $store) }}
+            - name: SQL_PASSWORD
+              {{- if $storeConfig.sql.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cadence.persistence.secretName" (list $ $store) }}
+                  key: {{ include "cadence.persistence.secretKey" (list $ $store) }}
+              {{- else }}
+              value: {{ include "cadence.persistence.sql.password" (list $ $store) }}
+              {{- end }}
+            {{- with $storeConfig.sql.connectAttributes }}
+            - name: SQL_CONNECT_ATTRIBUTES
+              value: {{ include "to-query" . }}
+            {{- end }}
+            {{- end }}
+        {{- end }}
+{{- end }}

--- a/charts/cadence/templates/server-secret.yaml
+++ b/charts/cadence/templates/server-secret.yaml
@@ -1,0 +1,26 @@
+{{- range $store := (list "default" "visibility") }}
+{{- $storeConfig := index $.Values.server.config.persistence $store }}
+{{- $driverConfig := index $storeConfig (include "cadence.persistence.driver" (list $ $store)) }}
+{{- $secretName := include "cadence.componentname" (list $ (printf "%s-store" $store)) }}
+{{- if and (not $driverConfig.existingSecret) (eq (include "cadence.persistence.secretName" (list $ $store)) $secretName) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    helm.sh/chart: {{ include "cadence.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+type: Opaque
+data:
+  {{- if eq (include "cadence.persistence.driver" (list $ $store)) "cassandra" }}
+  password: {{ $storeConfig.cassandra.password | b64enc | quote }}
+  {{- else if eq (include "cadence.persistence.driver" (list $ $store)) "sql" }}
+  password: {{ include "cadence.persistence.sql.password" (list $ $store) | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cadence/templates/server-service-monitor.yaml
+++ b/charts/cadence/templates/server-service-monitor.yaml
@@ -1,0 +1,40 @@
+{{- range $service := (list "frontend" "matching" "history" "worker") }}
+{{- $serviceValues := index $.Values.server $service -}}
+{{- if (default $.Values.server.metrics.serviceMonitor.enabled $serviceValues.metrics.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cadence.componentname" (list $ $service) }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    helm.sh/chart: {{ include "cadence.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: {{ $service }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+    {{- with (default $.Values.server.metrics.serviceMonitor.additionalLabels $serviceValues.metrics.serviceMonitor.additionalLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: {{ default $.Values.server.metrics.serviceMonitor.interval $serviceValues.metrics.serviceMonitor.interval }}
+      {{- with (default $.Values.server.metrics.serviceMonitor.relabellings $serviceValues.metrics.serviceMonitor.relabellings) }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  jobLabel: {{ include "cadence.componentname" (list $ $service) }}
+  namespaceSelector:
+    matchNames:
+      - "{{ $.Release.Namespace }}"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cadence.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: {{ $service }}
+      app.kubernetes.io/headless: 'true'
+
+---
+{{- end }}
+{{- end }}

--- a/charts/cadence/templates/server-service.yaml
+++ b/charts/cadence/templates/server-service.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cadence.componentname" (list . "frontend") }}
+  {{- with .Values.server.frontend.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+spec:
+  type: {{ .Values.server.frontend.service.type }}
+  ports:
+    - port: {{ .Values.server.frontend.service.port }}
+      targetPort: rpc
+      protocol: TCP
+      name: rpc
+      {{- if hasKey .Values.server.frontend.service "nodePort" }}
+      nodePort: {{ .Values.server.frontend.service.nodePort }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: frontend
+
+---
+{{- range $service := (list "frontend" "matching" "history" "worker") }}
+{{- $serviceValues := index $.Values.server $service -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cadence.componentname" (list $ (printf "%s-headless" $service)) }}
+
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    helm.sh/chart: {{ include "cadence.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: {{ $service }}
+    app.kubernetes.io/part-of: {{ $.Chart.Name }}
+    app.kubernetes.io/headless: 'true'
+  annotations:
+    # Use this annotation in addition to the actual field below because the
+    # annotation will stop being respected soon but the field is broken in
+    # some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    {{- with $serviceValues.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ $serviceValues.service.port }}
+      targetPort: rpc
+      protocol: TCP
+      name: rpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: {{ include "cadence.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: {{ $service }}
+
+---
+{{- end }}

--- a/charts/cadence/templates/web-deployment.yaml
+++ b/charts/cadence/templates/web-deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.web.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cadence.componentname" (list . "web") }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cadence.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "cadence.name" . }}
+        helm.sh/chart: {{ include "cadence.chart" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.web.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: check-frontend
+          securityContext:
+            {{- toYaml .Values.web.securityContext | nindent 12 }}
+          image: "{{ .Values.web.tcheck.image.repository }}:{{ .Values.web.tcheck.image.tag }}"
+          imagePullPolicy: {{ .Values.web.tcheck.image.pullPolicy }}
+          command: ['sh', '-c', 'until tcheck --peer {{ include "cadence.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }} --serviceName cadence-frontend; do echo waiting for frontend; sleep 2; done;']
+      containers:
+        - name: {{ .Chart.Name }}-web
+          securityContext:
+            {{- toYaml .Values.web.securityContext | nindent 12 }}
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          env:
+          - name: CADENCE_TCHANNEL_PEERS
+            value: "{{ include "cadence.fullname" . }}-frontend:{{ .Values.server.frontend.service.port }}"
+
+          ports:
+            - name: http
+              containerPort: 8088
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      {{- with .Values.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/cadence/templates/web-ingress.yaml
+++ b/charts/cadence/templates/web-ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.web.ingress.enabled -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "cadence.componentname" (list . "web") }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+{{- with .Values.web.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.web.ingress.tls }}
+  tls:
+  {{- range .Values.web.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.web.ingress.hosts }}
+  {{- $url := splitList "/" . }}
+    - host: {{ first $url }}
+      http:
+        paths:
+          - path: /{{ rest $url | join "/" }}
+            backend:
+              serviceName: {{ include "cadence.fullname" $ }}-web
+              servicePort: {{ $.Values.web.service.port }}
+  {{- end}}
+{{- end }}

--- a/charts/cadence/templates/web-service.yaml
+++ b/charts/cadence/templates/web-service.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.web.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cadence.componentname" (list . "web") }}
+  labels:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    helm.sh/chart: {{ include "cadence.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | replace "+" "_" }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+{{- with .Values.web.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.web.service.loadBalancerIP }}
+  loadBalancerIP: {{.}}
+{{- end }}
+  type: {{ .Values.web.service.type }}
+  ports:
+    - port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if hasKey .Values.web.service "nodePort" }}
+      nodePort: {{ .Values.web.service.nodePort }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "cadence.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: web
+{{- end }}

--- a/charts/cadence/values.dev.yaml
+++ b/charts/cadence/values.dev.yaml
@@ -1,0 +1,22 @@
+server:
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+
+cassandra:
+  enabled: true
+  livenessProbe:
+    initialDelaySeconds: 0
+  readinessProbe:
+    initialDelaySeconds: 0
+  config:
+    num_tokens: 0
+    max_heap_size: 512M
+    heap_new_size: 128M
+    seed_size: 0
+  env:
+    JVM_OPTS: |-
+      -Dcassandra.skip_wait_for_gossip_to_settle=0
+      -Dcassandra.initial_token=0
+    persistence:
+      enabled: true

--- a/charts/cadence/values.prod.yaml
+++ b/charts/cadence/values.prod.yaml
@@ -1,0 +1,52 @@
+server:
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+
+  config:
+    persistence:
+      default:
+        driver: "" # cassandra or sql
+
+        cassandra:
+          hosts: []
+          # port: 9042
+          keyspace: cadence
+          user: ""
+          password: ""
+
+        sql:
+          pluginName: "" # mysql
+          host: ""
+          # port: 3306
+          database: cadence
+          user: ""
+          password: ""
+
+      visibility:
+        driver: "" # cassandra or sql
+
+        cassandra:
+          hosts: []
+          # port: 9042
+          keyspace: cadence_visibility
+          user: ""
+          password: ""
+
+        sql:
+          pluginName: "" # mysql
+          host: ""
+          # port: 3306
+          database: cadence_visibility
+          user: ""
+          password: ""
+
+schema:
+  setup: false
+  update: false
+
+cassandra:
+  enabled: false
+
+mysql:
+  enabled: false

--- a/charts/cadence/values.yaml
+++ b/charts/cadence/values.yaml
@@ -1,0 +1,404 @@
+nameOverride: ""
+fullnameOverride: ""
+
+# Chart debug mode
+# (eg. disable helm hook delete policy)
+debug: false
+
+server:
+  image:
+    repository: ubercadence/server
+    tag: 0.24.0
+    pullPolicy: IfNotPresent
+
+  # Global default settings (can be overridden per service)
+  replicaCount: 1
+  metrics:
+    # Annotate pods directly with Prometheus annotations.
+    # Use this if you installed Prometheus from a Helm chart.
+    annotations:
+      enabled: false
+    # Enable Prometheus ServiceMonitor
+    # Use this if you installed the Prometheus Operator (https://github.com/coreos/prometheus-operator).
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+    prometheus:
+      timerType: histogram
+    statsd: {}
+      #   hostPort: localhost:8125
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  config:
+    # clusterMetadata contains the settings of the Cadence clusters
+    # participating in a Cadence cluster group.
+    clusterMetadata:
+      # enableGlobalDomain when set to true allows creating global domains which
+      # are replicated between all Cadence clusters distributed among different
+      # Kubernetes clusters and whose tasks are served by the active Cadence
+      # cluster in the replication.
+      #
+      # WARNING: This value **MUST NOT** be changed after launching the first
+      # Cadence cluster of the Cadence cluster group.
+      enableGlobalDomain: true
+
+      # maximumClusterCount defines and locks the maximum number of Cadence
+      # clusters of a Cadence cluster group at any point in the future included
+      # clusters added later.
+      #
+      # The requirement for this is to be able to safely determine a
+      # failoverVersionIncrement and initialFailoverVersion for each cluster
+      # automatically, accounting for clusters which are potentially being added
+      # later on to the cluster group and ensuring unique failover versions for
+      # each cluster all the time.
+      #
+      # failoverVersionIncrement is the increment of each cluster version when
+      # failover happens.
+      #
+      # initialFailoverVersion is the failover version a cluster starts at when
+      # launched.
+      #
+      # WARNING: For each Cadence cluster, (initialFailoverVersion +
+      # i*failoverVersionIncrement) **MUST** result in a unique value, not used
+      # by any other cluster.
+      #
+      # WARNING: This value **MUST NOT** be changed after launching the first
+      # Cadence cluster of the Cadence cluster group.
+      maximumClusterCount: 100
+
+      # masterClusterName is the name of the Cadence leader cluster in a Cadence
+      # cluster group which can register a domain, while each cluster can update
+      # domains and do domain failover.
+      #
+      # WARNING: it **MUST** be set to the same value for all Cadence clusters
+      # in a Cadence cluster group.
+      masterClusterName: "cluster-0"
+
+      # currentClusterName is the name of the Cadence cluster the configuration
+      # belongs to.
+      #
+      # In a Cadence cluster group, this is the particular Cadence
+      # cluster being installed with the chart on a Kubernetes cluster.
+      #
+      # WARNING: This value **MUST NOT** be changed after launching the Cadence
+      # cluster.
+      currentClusterName: "cluster-0"
+      
+      # clusterInformation contains the information about each Cadence cluster
+      # which participates in a Cadence cluster group.
+      #
+      # WARNING: for each Cadence cluster at any moment, the cluster names,
+      # initialFailoverVersion values and (initialFailoverVersion +
+      # i*failoverVersionIncrement) **MUST** be a unique value, not used by any
+      # other cluster.
+      #
+      # WARNING: once the Cadence cluster group is launched, you **MUST** only
+      # add Cadence clusters to the clusterInformation list and **MUST NOT**
+      # remove any Cadence cluster, although you **MAY** disable listed
+      # clusters.
+      #
+      # WARNING: you **MUST** list the Cadence clusters of a Cadence cluster
+      # group in the same order in each configuration to ensure the
+      # initialFailoverVersions are synchronized.
+      clusterInformation:
+        - name: cluster-0
+          # enabled defines whether the Cadence cluster is enabled.
+          enabled: true
+          # rpcAddress defines the address (host:port, host can be a DNS name)
+          # of the Cadence frontend remote service to use in a Cadence cluster.
+          #
+          # This is defaulted to the in-cluster Cadence frontend service, using
+          # the chart configured release name and frontend port, but can be
+          # manually overridden here if necessary.
+          # rpcAddress: cadence-frontend:7933
+        # - name: cluster-1
+        #   enabled: true
+
+    logLevel: "debug,info"
+    levelKey: "level"
+
+    # IMPORTANT: This value cannot be changed, once it's set.
+    numHistoryShards: 512
+
+    persistence:
+      default:
+        driver: "" # cassandra or sql
+
+        cassandra:
+          hosts: []
+          # port: 9042
+          keyspace: cadence
+          user: ""
+          password: ""
+          existingSecret: ""
+          # datacenter: "us-east-1a"
+          # maxConns: 2
+
+          # protoVersion is the protocol Version to connect to cassandra host.
+          # protoVersion: 4
+
+        sql:
+          pluginName: "" # mysql
+          host: ""
+          # port: 3306
+          database: cadence
+          user: ""
+          password: ""
+          existingSecret: ""
+          # maxConns: 20
+          # maxIdleConns: 20
+          # maxConnLifetime: "1h"
+          # connectAttributes:
+            # tx_isolation: "READ-COMMITTED"
+
+      visibility:
+        driver: "" # cassandra or sql
+
+        cassandra:
+          hosts: []
+          # port: 9042
+          keyspace: cadence_visibility
+          user: ""
+          password: ""
+          existingSecret: ""
+          # datacenter: "us-east-1a"
+          # maxConns: 2
+
+          # protoVersion is the protocol Version to connect to cassandra host.
+          # protoVersion: 4
+
+        sql:
+          pluginName: "" # mysql
+          host: ""
+          # port: 3306
+          database: cadence_visibility
+          user: ""
+          password: ""
+          existingSecret: ""
+          # maxConns: 20
+          # maxIdleConns: 20
+          # maxConnLifetime: "1h"
+          # connectAttributes:
+            # tx_isolation: "READ-COMMITTED"
+
+  frontend:
+    # replicaCount: 1
+    service:
+      type: ClusterIP
+      grpcPort: 7833
+      port: 7933
+      transport: grpc # grpc or tchannel
+      annotations: {}
+    metrics:
+      annotations: {}
+        # enabled: false
+      serviceMonitor: {}
+        # enabled: false
+      prometheus: {}
+        # timerType: histogram
+      statsd: {}
+      #   hostPort: localhost:8125
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  history:
+    # replicaCount: 1
+    service:
+      # type: ClusterIP
+      grpcPort: 7834
+      port: 7934
+      annotations: {}
+    metrics:
+      annotations: {}
+        # enabled: false
+      serviceMonitor: {}
+        # enabled: false
+      prometheus: {}
+        # timerType: histogram
+      statsd: {}
+      #   hostPort: localhost:8125
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  matching:
+    # replicaCount: 1
+    service:
+      # type: ClusterIP
+      grpcPort: 7835
+      port: 7935
+      annotations: {}
+    metrics:
+      annotations: {}
+        # enabled: false
+      serviceMonitor: {}
+        # enabled: false
+      prometheus: {}
+        # timerType: histogram
+      statsd: {}
+      #   hostPort: localhost:8125
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+  worker:
+    # replicaCount: 1
+    service:
+      # type: ClusterIP
+      port: 7939
+      annotations: {}
+    metrics:
+      annotations: {}
+        # enabled: false
+      serviceMonitor: {}
+        # enabled: false
+      prometheus: {}
+        # timerType: histogram
+      statsd: {}
+      #   hostPort: localhost:8125
+    podAnnotations: {}
+    podSecurityContext: {}
+    securityContext: {}
+    resources: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+web:
+  enabled: true
+
+  replicaCount: 1
+
+  image:
+    repository: ubercadence/web
+    tag: v3.32.0
+    pullPolicy: IfNotPresent
+
+  tcheck:
+    image:
+      repository: ghcr.io/banzaicloud/tcheck
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80
+    annotations: {}
+    # loadBalancerIP:
+
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: traefik
+      # ingress.kubernetes.io/ssl-redirect: "false"
+      # traefik.frontend.rule.type: PathPrefix
+    hosts:
+      - "/"
+      # - "domain.com/xyz"
+      # - "domain.com"
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+dynamicConfig:
+  values: {}
+  pollInterval: "10s"
+
+schema:
+  setup:
+    enabled: true
+    backoffLimit: 100
+  update:
+    enabled: true
+    backoffLimit: 100
+
+cassandra:
+  enabled: true
+  image:
+    repo: cassandra
+    tag: 3.11.3
+    pullPolicy: IfNotPresent
+  config:
+    cluster_size: 1
+    ports:
+      cql: 9042
+
+mysql:
+  enabled: false
+  imageTag: "5.7.26"
+  service:
+    port: 3306
+  mysqlUser: cadence
+  initializationFiles:
+    user.sql: |-
+      GRANT ALL PRIVILEGES ON *.* TO 'cadence'@'%';

--- a/charts/cadence/values/cassandra.yaml
+++ b/charts/cadence/values/cassandra.yaml
@@ -1,0 +1,18 @@
+image:
+  tag: 3.11.3
+livenessProbe:
+  initialDelaySeconds: 0
+readinessProbe:
+  initialDelaySeconds: 0
+config:
+  cluster_size: 1
+  num_tokens: 0
+  max_heap_size: 512M
+  heap_new_size: 128M
+  seed_size: 0
+env:
+  JVM_OPTS: |-
+    -Dcassandra.skip_wait_for_gossip_to_settle=0
+    -Dcassandra.initial_token=0
+  persistence:
+    enabled: true

--- a/charts/cadence/values/mysql.yaml
+++ b/charts/cadence/values/mysql.yaml
@@ -1,0 +1,10 @@
+  imageTag: "5.7.26"
+  mysqlUser: cadence
+  mysqlPassword: cadence
+  initializationFiles:
+    cadence.sql: |-
+      CREATE DATABASE IF NOT EXISTS cadence;
+      GRANT ALL PRIVILEGES ON cadence.* TO 'cadence'@'%';
+
+      CREATE DATABASE IF NOT EXISTS cadence_visibility;
+      GRANT ALL PRIVILEGES ON cadence_visibility.* TO 'cadence'@'%';

--- a/charts/cadence/values/values.cassandra.yaml
+++ b/charts/cadence/values/values.cassandra.yaml
@@ -1,0 +1,35 @@
+server:
+  config:
+    persistence:
+      default:
+        driver: "cassandra"
+
+        cassandra:
+          hosts: "cassandra-0.cassandra"
+          port: 9042
+          keyspace: "cadence"
+
+          # protoVersion is the protocol Version to connect to cassandra host.
+          # protoVersion: 4
+
+          # Authentication
+          # user: ""
+          # password: ""
+
+      visibility:
+        driver: "cassandra"
+
+        cassandra:
+          hosts: "cassandra-0.cassandra"
+          port: 9042
+          keyspace: "cadence_visibility"
+
+          # protoVersion is the protocol Version to connect to cassandra host.
+          # protoVersion: 4
+
+          # Authentication
+          # user: ""
+          # password: ""
+
+cassandra:
+  enabled: false

--- a/charts/cadence/values/values.dynamic.yaml
+++ b/charts/cadence/values/values.dynamic.yaml
@@ -1,0 +1,5 @@
+dynamicConfig:
+  values:
+    frontend.enableClientVersionCheck:
+      - value: true
+        constraints: {}

--- a/charts/cadence/values/values.mysql.yaml
+++ b/charts/cadence/values/values.mysql.yaml
@@ -1,0 +1,27 @@
+server:
+  config:
+    persistence:
+      default:
+        driver: "sql"
+
+        sql:
+          pluginName: "mysql"
+          host: "mysql"
+          port: 3306
+          database: cadence
+          user: "cadence"
+          password: "cadence"
+
+      visibility:
+        driver: "sql"
+
+        sql:
+          pluginName: "mysql"
+          host: "mysql"
+          port: 3306
+          database: cadence_visibility
+          user: "cadence"
+          password: "cadence"
+
+cassandra:
+  enabled: false


### PR DESCRIPTION
This pull requests add the Cadence chart from BanzaiCloud repo at tag 0.24.2, the latest released tag https://github.com/banzaicloud/banzai-charts/commit/2c6aec9e5432e527c4728710c671d54eded11351 and adds a CI pipeline to confirm we are not diverging. The pipeline is only added for safety checks and will be removed in subsequent pull requests.

The original CI pipeline from BanzaiCloud is kept, even if it doesn't work in this setup. It will be addressed in #2 

Fixes #1 