### PR TITLE
Adding chart testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,3 +37,10 @@ jobs:
 
       - name: Lint chart
         run: ct lint --all --config ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+
+      - name: Run chart-testing (install)
+        run: |
+          ct install --all --config ct.yaml --helm-extra-args="--timeout 10m"

--- a/charts/cadence/ci/persistence-cassandra-values.yaml
+++ b/charts/cadence/ci/persistence-cassandra-values.yaml
@@ -1,0 +1,22 @@
+server:
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+
+cassandra:
+  enabled: true
+  livenessProbe:
+    initialDelaySeconds: 0
+  readinessProbe:
+    initialDelaySeconds: 0
+  config:
+    num_tokens: 0
+    max_heap_size: 512M
+    heap_new_size: 128M
+    seed_size: 0
+  env:
+    JVM_OPTS: |-
+      -Dcassandra.skip_wait_for_gossip_to_settle=0
+      -Dcassandra.initial_token=0
+    persistence:
+      enabled: true

--- a/charts/cadence/ci/persistence-mysql-values.yaml
+++ b/charts/cadence/ci/persistence-mysql-values.yaml
@@ -1,0 +1,15 @@
+server:
+  podAnnotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '9090'
+  config:
+    persistence:
+      default:
+        driver: "sql"
+
+cassandra:
+  enabled: false
+
+mysql:
+  enabled: true
+  mysqlPassword: "cadence"


### PR DESCRIPTION
Adding 2 CI/CD tests using Kind: one of them is derived by `values.dev.sql` and the other is a similar configuration for MySQL to address #5. Both tests will now fail for the reason discussed in #6

In the logs, it's possible to read:

```
Installing chart with values file "charts/cadence/ci/persistence-cassandra-values.yaml"...
```

and
```
Installing chart with values file "charts/cadence/ci/persistence-mysql-values.yaml"...
```