### PR TITLE
Add a local fork of Cassandra and MySQL

### DIFF
--- a/.github/workflows/chart-migration-check.yml
+++ b/.github/workflows/chart-migration-check.yml
@@ -1,0 +1,63 @@
+name: Charts Diff
+
+on:
+  pull_request:
+    paths:
+    - 'charts/mysql/**'
+    - 'charts/cassandra/**'
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
+    steps:
+
+    - name: Checkout Current Repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    # Repo is now archied, so master is a stable commit
+    - name: Checkout Helm/Charts Master for MySQL
+      uses: actions/checkout@v2
+      with:
+        repository: helm/charts
+        ref: master
+        path: upstream-charts
+
+    - name: Diff Charts
+      run: |
+        make diff-charts \
+        LEGACY_HELM_CHARTS_DIR="./upstream-charts" \
+        DIFF_OUTPUT_DIR="./observed_diffs"
+
+    - name: Prepare Diffs for Comment
+      run: |
+        echo "MYSQL_DIFF<<EOF" >> $GITHUB_ENV
+        cat observed_diffs/mysql.diff >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+        echo "CASSANDRA_DIFF<<EOF" >> $GITHUB_ENV
+        cat observed_diffs/cassandra.diff >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+    - name: MySQL Diff
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: MySQL Differences
+        message: |
+            # MySQL Chart Diff
+            ```diff
+            ${{ env.MYSQL_DIFF }}
+            ```
+
+    - name: Cassandra Diff
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: Cassandra Differences
+        message: |
+            # Cassandra Chart Diff
+            ```diff
+            ${{ env.CASSANDRA_DIFF }}
+            ```

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: ^charts/(mysql|cassandra)/
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,25 @@
-.PHONY: setup update-deps
+.PHONY: setup update-deps all diff-charts clean
+
+LEGACY_HELM_CHARTS_DIR := ../charts
+DIFF_OUTPUT_DIR := ./charts-diff
 
 update-deps:
 	helm dependency update charts/cadence
 
 setup: update-deps
 	pre-commit install
+
+all: clean diff-charts
+
+${DIFF_OUTPUT_DIR}/mysql.diff: charts/mysql ${LEGACY_HELM_CHARTS_DIR}/stable/mysql
+	mkdir -p ${DIFF_OUTPUT_DIR}
+	git diff --no-index $(LEGACY_HELM_CHARTS_DIR)/stable/mysql $< > $@ || true
+
+${DIFF_OUTPUT_DIR}/cassandra.diff: charts/cassandra ${LEGACY_HELM_CHARTS_DIR}/incubator/cassandra
+	mkdir -p ${DIFF_OUTPUT_DIR}
+	git diff --no-index $(LEGACY_HELM_CHARTS_DIR)/incubator/cassandra $< > $@ || true
+
+diff-charts: ${DIFF_OUTPUT_DIR}/cassandra.diff ${DIFF_OUTPUT_DIR}/mysql.diff
+
+clean:
+	rm -f ${DIFF_OUTPUT_DIR}/*.diff

--- a/README.md
+++ b/README.md
@@ -414,6 +414,11 @@ $ helm install --name my-release --values values.yaml cadence/cadence
 
 You can download dependencies and install the pre-commit hooks using `make setup` or update the dependencies running `make update-dependencies`
 
+### Testing
+
+To implement test automation for the Helm Chart with GitHub Actions, it was necessary to create a local fork of the database charts to ensure some resources that do not support annotations could be initialized in the correct order. When a PR like
+https://github.com/helm/chart-testing/pull/243/files will be merged, we could use Helm Post Renderer to add annotations to resources in Charts that do not support annotating them, or alternatively we could remove database charts as dependencies and pre-install them to simplify tasting but at the cost of worse developer experience.
+
 ### New release process.
 The new release process use GitHub Pages as an Helm Chart Repository. In order to test the release, set up GitHub Pages for your fork. This will allow you to see how your changes affect the final outcome. Please create a branch named `gh-pages` and enabled on your repository GitHub Pages from that branch. If you need more information, please consult the [Chart Releaser Action Documentation](https://github.com/helm/chart-releaser-action)
 

--- a/charts/cadence/requirements.lock
+++ b/charts/cadence/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cassandra
-  repository: https://charts.helm.sh/incubator
-  version: 0.13.4
+  repository: file://../cassandra
+  version: 0.15.4
 - name: mysql
-  repository: https://charts.helm.sh/stable
+  repository: file://../mysql
   version: 1.6.9
-digest: sha256:2d4e9a7e9cb5917e7e7092e9c329e51004155b25b7b1ecfd773b113d8a092b5d
-generated: "2023-08-08T18:47:30.218128-07:00"
+digest: sha256:9131bb19144b4d00e95556f221845e9f16ca7991aa243180d195044cc0d34ee9
+generated: "2023-08-10T06:47:37.341414-07:00"

--- a/charts/cadence/requirements.yaml
+++ b/charts/cadence/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: cassandra
-    version: ^0.13.1
-    repository: https://charts.helm.sh/incubator
+    version: ^0.15.4
+    repository: "file://../cassandra"
     condition: cassandra.enabled
   - name: mysql
     version: ^1.2.0
-    repository: https://charts.helm.sh/stable
+    repository: "file://../mysql"
     condition: mysql.enabled

--- a/charts/cassandra/.helmignore
+++ b/charts/cassandra/.helmignore
@@ -1,0 +1,17 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+OWNERS

--- a/charts/cassandra/Chart.yaml
+++ b/charts/cassandra/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+name: cassandra
+version: 0.15.4
+appVersion: 3.11.6
+description: DEPRECATED Apache Cassandra is a free and open-source distributed database management
+  system designed to handle large amounts of data across many commodity servers, providing
+  high availability with no single point of failure.
+icon: https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/Cassandra_logo.svg/330px-Cassandra_logo.svg.png
+keywords:
+- cassandra
+- database
+- nosql
+home: http://cassandra.apache.org
+deprecated: true
+engine: gotpl

--- a/charts/cassandra/README.md
+++ b/charts/cassandra/README.md
@@ -1,0 +1,227 @@
+# ⚠️ Repo Archive Notice
+
+As of Nov 13, 2020, charts in this repo will no longer be updated.
+For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
+
+# Cassandra
+A Cassandra Chart for Kubernetes
+
+## DEPRECATION NOTICE
+
+This chart is deprecated and no longer supported.
+
+## Install Chart
+To install the Cassandra Chart into your Kubernetes cluster (This Chart requires persistent volume by default, you may need to create a storage class before install chart. To create storage class, see [Persist data](#persist_data) section)
+
+```bash
+helm install --namespace "cassandra" -n "cassandra" incubator/cassandra
+```
+
+After installation succeeds, you can get a status of Chart
+
+```bash
+helm status "cassandra"
+```
+
+If you want to delete your Chart, use this command
+```bash
+helm delete  --purge "cassandra"
+```
+
+## Upgrading
+
+To upgrade your Cassandra release, simply run
+
+```bash
+helm upgrade "cassandra" incubator/cassandra
+```
+
+### 0.12.0
+
+This version fixes https://github.com/helm/charts/issues/7803 by removing mutable labels in `spec.VolumeClaimTemplate.metadata.labels` so that it is upgradable.
+
+Until this version, in order to upgrade, you have to delete the Cassandra StatefulSet before upgrading:
+```bash
+$ kubectl delete statefulset --cascade=false my-cassandra-release
+```
+
+
+## Persist data
+You need to create `StorageClass` before able to persist data in persistent volume.
+To create a `StorageClass` on Google Cloud, run the following
+
+```bash
+kubectl create -f sample/create-storage-gce.yaml
+```
+
+And set the following values in `values.yaml`
+
+```yaml
+persistence:
+  enabled: true
+```
+
+If you want to create a `StorageClass` on other platform, please see documentation here [https://kubernetes.io/docs/user-guide/persistent-volumes/](https://kubernetes.io/docs/user-guide/persistent-volumes/)
+
+When running a cluster without persistence, the termination of a pod will first initiate a decommissioning of that pod.
+Depending on the amount of data stored inside the cluster this may take a while. In order to complete a graceful
+termination, pods need to get more time for it. Set the following values in `values.yaml`:
+
+```yaml
+podSettings:
+  terminationGracePeriodSeconds: 1800
+```
+
+## Install Chart with specific cluster size
+By default, this Chart will create a cassandra with 3 nodes. If you want to change the cluster size during installation, you can use `--set config.cluster_size={value}` argument. Or edit `values.yaml`
+
+For example:
+Set cluster size to 5
+
+```bash
+helm install --namespace "cassandra" -n "cassandra" --set config.cluster_size=5 incubator/cassandra/
+```
+
+## Install Chart with specific resource size
+By default, this Chart will create a cassandra with CPU 2 vCPU and 4Gi of memory which is suitable for development environment.
+If you want to use this Chart for production, I would recommend to update the CPU to 4 vCPU and 16Gi. Also increase size of `max_heap_size` and `heap_new_size`.
+To update the settings, edit `values.yaml`
+
+## Install Chart with specific node
+Sometime you may need to deploy your cassandra to specific nodes to allocate resources. You can use node selector by edit `nodes.enabled=true` in `values.yaml`
+For example, you have 6 vms in node pools and you want to deploy cassandra to node which labeled as `cloud.google.com/gke-nodepool: pool-db`
+
+Set the following values in `values.yaml`
+
+```yaml
+nodes:
+  enabled: true
+  selector:
+    nodeSelector:
+      cloud.google.com/gke-nodepool: pool-db
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Cassandra chart and their default values.
+
+| Parameter                  | Description                                     | Default                                                    |
+| -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
+| `image.repo`                         | `cassandra` image repository                    | `cassandra`                                                |
+| `image.tag`                          | `cassandra` image tag                           | `3.11.5`                                                   |
+| `image.pullPolicy`                   | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `image.pullSecrets`                  | Image pull secrets                              | `nil`                                                      |
+| `config.cluster_domain`              | The name of the cluster domain.                 | `cluster.local`                                            |
+| `config.cluster_name`                | The name of the cluster.                        | `cassandra`                                                |
+| `config.cluster_size`                | The number of nodes in the cluster.             | `3`                                                        |
+| `config.seed_size`                   | The number of seed nodes used to bootstrap new clients joining the cluster.                            | `2` |
+| `config.seeds`                       | The comma-separated list of seed nodes.         | Automatically generated according to `.Release.Name` and `config.seed_size` |
+| `config.num_tokens`                  | Initdb Arguments                                | `256`                                                      |
+| `config.dc_name`                     | Initdb Arguments                                | `DC1`                                                      |
+| `config.rack_name`                   | Initdb Arguments                                | `RAC1`                                                     |
+| `config.endpoint_snitch`             | Initdb Arguments                                | `SimpleSnitch`                                             |
+| `config.max_heap_size`               | Initdb Arguments                                | `2048M`                                                    |
+| `config.heap_new_size`               | Initdb Arguments                                | `512M`                                                     |
+| `config.ports.cql`                   | Initdb Arguments                                | `9042`                                                     |
+| `config.ports.thrift`                | Initdb Arguments                                | `9160`                                                     |
+| `config.ports.agent`                 | The port of the JVM Agent (if any)              | `nil`                                                      |
+| `config.start_rpc`                   | Initdb Arguments                                | `false`                                                    |
+| `configOverrides`                    | Overrides config files in /etc/cassandra dir    | `{}`                                                       |
+| `commandOverrides`                   | Overrides default docker command                | `[]`                                                       |
+| `argsOverrides`                      | Overrides default docker args                   | `[]`                                                       |
+| `env`                                | Custom env variables                            | `{}`                                                       |
+| `schedulerName`                      | Name of k8s scheduler (other than the default)  | `nil`                                                      |
+| `persistence.enabled`                | Use a PVC to persist data                       | `true`                                                     |
+| `persistence.storageClass`           | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`             | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
+| `persistence.size`                   | Size of data volume                             | `10Gi`                                                     |
+| `resources`                          | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
+| `service.type`                       | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
+| `service.annotations`                | Annotations to apply to cassandra service       | `""`                                                       |
+| `podManagementPolicy`                | podManagementPolicy of the StatefulSet          | `OrderedReady`                                             |
+| `podDisruptionBudget`                | Pod distruption budget                          | `{}`                                                       |
+| `podAnnotations`                     | pod annotations for the StatefulSet             | `{}`                                                       |
+| `updateStrategy.type`                | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated        | `90`                                                       |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                  | `30`                                                       |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                        | `5`                                                        |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated       | `90`                                                       |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                  | `30`                                                       |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                        | `5`                                                        |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
+| `readinessProbe.address`             | Address to use for checking node has joined the cluster and is ready.                          | `${POD_IP}` |
+| `rbac.create`                        | Specifies whether RBAC resources should be created                                                  | `true` |
+| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                | `true` |
+| `serviceAccount.name`                | The name of the ServiceAccount to use           |                                                            |
+| `backup.enabled`                     | Enable backup on chart installation             | `false`                                                    |
+| `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
+| `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |
+| `backup.image.repository`            | Backup image repository                         | `maorfr/cain`                                              |
+| `backup.image.tag`                   | Backup image tag                                | `0.6.0`                                                    |
+| `backup.extraArgs`                   | Additional arguments for cain                   | `[]`                                                       |
+| `backup.env`                         | Backup environment variables                    | AWS_REGION: `us-east-1`                                    |
+| `backup.resources`                   | Backup CPU/Memory resource requests/limits      | Memory: `1Gi`, CPU: `1`                                    |
+| `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |
+| `backup.google.serviceAccountSecret` | Secret containing credentials if GCS is used as destination |                                                |
+| `exporter.enabled`                   | Enable Cassandra exporter                       | `false`                                                    |
+| `exporter.servicemonitor.enabled`    | Enable ServiceMonitor for exporter              | `true`                                                    |
+| `exporter.servicemonitor.additionalLabels`| Additional labels for Service Monitor           | `{}`                                                       |
+| `exporter.image.repo`                | Exporter image repository                       | `criteord/cassandra_exporter`                              |
+| `exporter.image.tag`                 | Exporter image tag                              | `2.0.2`                                                    |
+| `exporter.port`                      | Exporter port                                   | `5556`                                                     |
+| `exporter.jvmOpts`                   | Exporter additional JVM options                 |                                                            |
+| `exporter.resources`                 | Exporter CPU/Memory resource requests/limits    | `{}`                                                       |
+| `extraContainers`                    | Sidecar containers for the pods                 | `[]`                                                       |
+| `extraVolumes`                       | Additional volumes for the pods                 | `[]`                                                       |
+| `extraVolumeMounts`                  | Extra volume mounts for the pods                | `[]`                                                       |
+| `affinity`                           | Kubernetes node affinity                        | `{}`                                                       |
+| `tolerations`                        | Kubernetes node tolerations                     | `[]`                                                       |
+
+
+## Scale cassandra
+When you want to change the cluster size of your cassandra, you can use the helm upgrade command.
+
+```bash
+helm upgrade --set config.cluster_size=5 cassandra incubator/cassandra
+```
+
+## Get cassandra status
+You can get your cassandra cluster status by running the command
+
+```bash
+kubectl exec -it --namespace cassandra $(kubectl get pods --namespace cassandra -l app=cassandra-cassandra -o jsonpath='{.items[0].metadata.name}') nodetool status
+```
+
+Output
+```bash
+Datacenter: asia-east1
+======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address    Load       Tokens       Owns (effective)  Host ID                               Rack
+UN  10.8.1.11  108.45 KiB  256          66.1%             410cc9da-8993-4dc2-9026-1dd381874c54  a
+UN  10.8.4.12  84.08 KiB  256          68.7%             96e159e1-ef94-406e-a0be-e58fbd32a830  c
+UN  10.8.3.6   103.07 KiB  256          65.2%             1a42b953-8728-4139-b070-b855b8fff326  b
+```
+
+## Benchmark
+You can use [cassandra-stress](https://docs.datastax.com/en/cassandra/3.0/cassandra/tools/toolsCStress.html) tool to run the benchmark on the cluster by the following command
+
+```bash
+kubectl exec -it --namespace cassandra $(kubectl get pods --namespace cassandra -l app=cassandra-cassandra -o jsonpath='{.items[0].metadata.name}') cassandra-stress
+```
+
+Example of `cassandra-stress` argument
+ - Run both read and write with ration 9:1
+ - Operator total 1 million keys with uniform distribution
+ - Use QUORUM for read/write
+ - Generate 50 threads
+ - Generate result in graph
+ - Use NetworkTopologyStrategy with replica factor 2
+
+```bash
+cassandra-stress mixed ratio\(write=1,read=9\) n=1000000 cl=QUORUM -pop dist=UNIFORM\(1..1000000\) -mode native cql3 -rate threads=50 -log file=~/mixed_autorate_r9w1_1M.log -graph file=test2.html title=test revision=test2 -schema "replication(strategy=NetworkTopologyStrategy, factor=2)"
+```

--- a/charts/cassandra/sample/create-storage-gce.yaml
+++ b/charts/cassandra/sample/create-storage-gce.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: generic
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/charts/cassandra/templates/NOTES.txt
+++ b/charts/cassandra/templates/NOTES.txt
@@ -1,0 +1,35 @@
+Cassandra CQL can be accessed via port {{ .Values.config.ports.cql }} on the following DNS name from within your cluster:
+Cassandra Thrift can be accessed via port {{ .Values.config.ports.thrift }} on the following DNS name from within your cluster:
+
+If you want to connect to the remote instance with your local Cassandra CQL cli. To forward the API port to localhost:9042 run the following:
+- kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "cassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{ .items[0].metadata.name }') 9042:{{ .Values.config.ports.cql }}
+
+If you want to connect to the Cassandra CQL run the following:
+{{- if contains "NodePort" .Values.service.type }}
+- export CQL_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "cassandra.fullname" . }})
+- export CQL_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+- cqlsh $CQL_HOST $CQL_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "cassandra.fullname" . }}'
+- export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "cassandra.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+- echo cqlsh $SERVICE_IP
+{{- else if contains "ClusterIP" .Values.service.type }}
+- kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "cassandra.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}") 9042:{{ .Values.config.ports.cql }}
+  echo cqlsh 127.0.0.1 9042
+{{- end }}
+
+You can also see the cluster status by run the following:
+- kubectl exec -it --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "cassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{.items[0].metadata.name}') nodetool status
+
+To tail the logs for the Cassandra pod run the following:
+- kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "cassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{ .items[0].metadata.name }')
+
+{{- if not .Values.persistence.enabled }}
+
+Note that the cluster is running with node-local storage instead of PersistentVolumes. In order to prevent data loss,
+pods will be decommissioned upon termination. Decommissioning may take some time, so you might also want to adjust the
+pod termination gace period, which is currently set to {{ .Values.podSettings.terminationGracePeriodSeconds }} seconds.
+
+{{- end}}

--- a/charts/cassandra/templates/_helpers.tpl
+++ b/charts/cassandra/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cassandra.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cassandra.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cassandra.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cassandra.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cassandra.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/cassandra/templates/backup/cronjob.yaml
+++ b/charts/cassandra/templates/backup/cronjob.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.backup.enabled }}
+{{- $release := .Release }}
+{{- $values := .Values }}
+{{- $backup := $values.backup }}
+{{- range $index, $schedule := $backup.schedule }}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "cassandra.fullname" $ }}-backup-{{ $schedule.keyspace | replace "_" "-" }}
+  labels:
+    app: {{ template "cassandra.name" $ }}-cain
+    chart: {{ template "cassandra.chart" $ }}
+    release: "{{ $release.Name }}"
+    heritage: "{{ $release.Service }}"
+spec:
+  schedule: {{ $schedule.cron | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            {{ toYaml $backup.annotations }}
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ template "cassandra.serviceAccountName" $ }}
+          containers:
+          - name: cassandra-backup
+            image: "{{ $backup.image.repository }}:{{ $backup.image.tag }}"
+            command: ["cain"]
+            args:
+            - backup
+            - --namespace
+            - {{ $release.Namespace }}
+            - --selector
+            - release={{ $release.Name }},app={{ template "cassandra.name" $ }}
+            - --keyspace
+            - {{ $schedule.keyspace }}
+            - --dst
+            - {{ $backup.destination }}
+            {{- with $backup.extraArgs }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+            env:
+{{- if $backup.google.serviceAccountSecret }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/etc/secrets/google/credentials.json"
+{{- end }}
+          {{- with $backup.env }}
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with $backup.resources }}
+            resources:
+{{ toYaml . | indent 14 }}
+          {{- end }}
+{{- if $backup.google.serviceAccountSecret }}
+            volumeMounts:
+            - name: google-service-account
+              mountPath: /etc/secrets/google/
+{{- end }}
+{{- if $backup.google.serviceAccountSecret }}
+          volumes:
+          - name: google-service-account
+            secret:
+              secretName: {{ $backup.google.serviceAccountSecret | quote }}
+{{- end }}
+          affinity:
+            podAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - {{ template "cassandra.fullname" $ }}
+                    - key: release
+                      operator: In
+                      values:
+                      - {{ $release.Name }}
+                  topologyKey: "kubernetes.io/hostname"
+          {{- with $values.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cassandra/templates/backup/rbac.yaml
+++ b/charts/cassandra/templates/backup/rbac.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.backup.enabled }}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cassandra.serviceAccountName" . }}
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+---
+{{- end }}
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "cassandra.fullname" . }}-backup
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "cassandra.fullname" . }}-backup
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "cassandra.fullname" . }}-backup
+subjects:
+- kind: ServiceAccount
+  name: {{ template "cassandra.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/cassandra/templates/configmap.yaml
+++ b/charts/cassandra/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.configOverrides }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "cassandra.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{ toYaml .Values.configOverrides | indent 2 }}
+{{- end }}

--- a/charts/cassandra/templates/pdb.yaml
+++ b/charts/cassandra/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "cassandra.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cassandra.name" . }}
+      release: {{ .Release.Name }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/charts/cassandra/templates/service.yaml
+++ b/charts/cassandra/templates/service.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cassandra.fullname" . }}
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  type: {{ .Values.service.type }}
+  ports:
+    {{- if .Values.exporter.enabled }}
+  - name: metrics
+    port: 5556
+    targetPort: {{ .Values.exporter.port }}
+    {{- end }}
+  - name: intra
+    port: 7000
+    targetPort: 7000
+  - name: tls
+    port: 7001
+    targetPort: 7001
+  - name: jmx
+    port: 7199
+    targetPort: 7199
+  - name: cql
+    port: {{ default 9042 .Values.config.ports.cql }}
+    targetPort: {{ default 9042 .Values.config.ports.cql }}
+  - name: thrift
+    port: {{ default 9160 .Values.config.ports.thrift }}
+    targetPort: {{ default 9160 .Values.config.ports.thrift }}
+  {{- if .Values.config.ports.agent }}
+  - name: agent
+    port: {{ .Values.config.ports.agent }}
+    targetPort: {{ .Values.config.ports.agent }}
+  {{- end }}
+  selector:
+    app: {{ template "cassandra.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/cassandra/templates/servicemonitor.yaml
+++ b/charts/cassandra/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.exporter.enabled .Values.exporter.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cassandra.fullname" . }}
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.exporter.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.exporter.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  jobLabel: {{ template "cassandra.name" . }}
+  endpoints:
+  - port: metrics
+    interval: 10s
+  selector:
+    matchLabels:
+      app: {{ template "cassandra.name" . }}
+  namespaceSelector:
+    any: true
+{{- end }}

--- a/charts/cassandra/templates/statefulset.yaml
+++ b/charts/cassandra/templates/statefulset.yaml
@@ -1,0 +1,229 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "cassandra.fullname" . }}
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cassandra.name" . }}
+      release: {{ .Release.Name }}
+  serviceName: {{ template "cassandra.fullname" . }}
+  replicas: {{ .Values.config.cluster_size }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "cassandra.name" . }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
+{{- if .Values.selector }}
+{{ toYaml .Values.selector | indent 6 }}
+{{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.configOverrides }}
+      initContainers:
+      - name: config-copier
+        image: busybox
+        command: [ 'sh', '-c', 'cp /configmap-files/* /cassandra-configs/ && chown 999:999 /cassandra-configs/*']
+        volumeMounts:
+{{- range $key, $value := .Values.configOverrides }}
+        - name: cassandra-config-{{ $key | replace "." "-" | replace "_" "--" }}
+          mountPath: /configmap-files/{{ $key }}
+          subPath: {{ $key }}
+{{- end }}
+        - name: cassandra-configs
+          mountPath: /cassandra-configs/
+{{- end }}
+      containers:
+{{- if .Values.extraContainers }}
+{{ tpl (toYaml .Values.extraContainers) . | indent 6}}
+{{- end }}
+{{- if .Values.exporter.enabled }}
+      - name: cassandra-exporter
+        image: "{{ .Values.exporter.image.repo }}:{{ .Values.exporter.image.tag }}"
+        resources:
+{{ toYaml .Values.exporter.resources | indent 10 }}
+        env:
+          - name: CASSANDRA_EXPORTER_CONFIG_listenPort
+            value: {{ .Values.exporter.port | quote }}
+          - name: JVM_OPTS
+            value: {{ .Values.exporter.jvmOpts | quote }}
+        ports:
+          - name: metrics
+            containerPort: {{ .Values.exporter.port }}
+            protocol: TCP
+          - name: jmx
+            containerPort: 5555
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.exporter.port }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: {{ .Values.exporter.port }}
+          initialDelaySeconds: 20
+          timeoutSeconds: 45
+{{- end }}
+      - name: {{ template "cassandra.fullname" . }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+{{- if .Values.commandOverrides }}
+        command: {{ .Values.commandOverrides }}
+{{- end }}
+{{- if .Values.argsOverrides }}
+        args: {{ .Values.argsOverrides }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        {{- $seed_size := default 1 .Values.config.seed_size | int -}}
+        {{- $global := . }}
+        - name: CASSANDRA_SEEDS
+          {{- if .Values.hostNetwork }}
+          value: {{ required "You must fill \".Values.config.seeds\" with list of Cassandra seeds when hostNetwork is set to true" .Values.config.seeds | quote }}
+          {{- else }}
+          value: "{{- range $i, $e := until $seed_size }}{{ template "cassandra.fullname" $global }}-{{ $i }}.{{ template "cassandra.fullname" $global }}.{{ $global.Release.Namespace }}.svc.{{ $global.Values.config.cluster_domain }}{{- if (lt ( add1 $i ) $seed_size ) }},{{- end }}{{- end }}"
+          {{- end }}
+        - name: MAX_HEAP_SIZE
+          value: {{ default "8192M" .Values.config.max_heap_size | quote }}
+        - name: HEAP_NEWSIZE
+          value: {{ default "200M" .Values.config.heap_new_size | quote }}
+        - name: CASSANDRA_ENDPOINT_SNITCH
+          value: {{ default "SimpleSnitch" .Values.config.endpoint_snitch | quote }}
+        - name: CASSANDRA_CLUSTER_NAME
+          value: {{ default "Cassandra" .Values.config.cluster_name | quote }}
+        - name: CASSANDRA_DC
+          value: {{ default "DC1" .Values.config.dc_name | quote }}
+        - name: CASSANDRA_RACK
+          value: {{ default "RAC1" .Values.config.rack_name | quote }}
+        - name: CASSANDRA_START_RPC
+          value: {{ default "false" .Values.config.start_rpc | quote }}
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- range $key, $value := .Values.env }}
+        - name: {{ $key | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
+        livenessProbe:
+          exec:
+            command: [ "/bin/sh", "-c", "nodetool status" ]
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        readinessProbe:
+          exec:
+            command: [ "/bin/sh", "-c", "nodetool status | grep -E \"^UN\\s+{{ .Values.readinessProbe.address }}\"" ]
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        ports:
+        - name: intra
+          containerPort: 7000
+        - name: tls
+          containerPort: 7001
+        - name: jmx
+          containerPort: 7199
+        - name: cql
+          containerPort: {{ default 9042 .Values.config.ports.cql }}
+        - name: thrift
+          containerPort: {{ default 9160 .Values.config.ports.thrift }}
+        {{- if .Values.config.ports.agent }}
+        - name: agent
+          containerPort: {{ .Values.config.ports.agent }}
+        {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/cassandra
+        {{- if .Values.configOverrides }}
+        - name: cassandra-configs
+          mountPath: /etc/cassandra
+        {{- end }}
+        {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+        {{- end }}
+        {{- if not .Values.persistence.enabled }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "exec nodetool decommission"]
+        {{- end }}
+      terminationGracePeriodSeconds: {{ default 30 .Values.podSettings.terminationGracePeriodSeconds }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecrets }}
+      {{- end }}
+{{- if or .Values.extraVolumes ( or .Values.configOverrides (not .Values.persistence.enabled) ) }}
+      volumes:
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+{{- range $key, $value := .Values.configOverrides }}
+      - configMap:
+          name: cassandra
+        name: cassandra-config-{{ $key | replace "." "-" | replace "_" "--" }}
+{{- end }}
+{{- if .Values.configOverrides }}
+      - name: cassandra-configs
+        emptyDir: {}
+{{- end }}
+{{- if not .Values.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+{{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        app: {{ template "cassandra.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      accessModes:
+        - {{ .Values.persistence.accessMode | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+    {{- if .Values.persistence.storageClass }}
+    {{- if (eq "-" .Values.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.persistence.storageClass }}"
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/cassandra/values.yaml
+++ b/charts/cassandra/values.yaml
@@ -1,0 +1,254 @@
+## Cassandra image version
+## ref: https://hub.docker.com/r/library/cassandra/
+image:
+  repo: cassandra
+  tag: 3.11.6
+  pullPolicy: IfNotPresent
+  ## Specify ImagePullSecrets for Pods
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  # pullSecrets: myregistrykey
+
+## Specify a service type
+## ref: http://kubernetes.io/docs/user-guide/services/
+service:
+  type: ClusterIP
+  annotations: ""
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## Persist data to a persistent volume
+persistence:
+  enabled: true
+  ## cassandra data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## Minimum memory for development is 4GB and 2 CPU cores
+## Minimum memory for production is 8GB and 4 CPU cores
+## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
+resources: {}
+  # requests:
+  #   memory: 4Gi
+  #   cpu: 2
+  # limits:
+  #   memory: 4Gi
+  #   cpu: 2
+
+## Change cassandra configuration parameters below:
+## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html
+## Recommended max heap size is 1/2 of system memory
+## Recommended heap new size is 1/4 of max heap size
+## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/operations/opsTuneJVM.html
+config:
+  cluster_domain: cluster.local
+  cluster_name: cassandra
+  cluster_size: 3
+  seed_size: 2
+  num_tokens: 256
+  # If you want Cassandra to use this datacenter and rack name,
+  # you need to set endpoint_snitch to GossipingPropertyFileSnitch.
+  # Otherwise, these values are ignored and datacenter1 and rack1
+  # are used.
+  dc_name: DC1
+  rack_name: RAC1
+  endpoint_snitch: SimpleSnitch
+  max_heap_size: 2048M
+  heap_new_size: 512M
+  start_rpc: false
+  ports:
+    cql: 9042
+    thrift: 9160
+    # If a JVM Agent is in place
+    # agent: 61621
+
+## Cassandra config files overrides
+configOverrides: {}
+
+## Cassandra docker command overrides
+commandOverrides: []
+
+## Cassandra docker args overrides
+argsOverrides: []
+
+## Custom env variables.
+## ref: https://hub.docker.com/_/cassandra/
+env: {}
+
+## Liveness and Readiness probe values.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+readinessProbe:
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+  address: "${POD_IP}"
+
+## Configure node selector. Edit code below for adding selector to pods
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+# selector:
+  # nodeSelector:
+    # cloud.google.com/gke-nodepool: pool-db
+
+## Additional pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+
+## Additional pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+## Additional pod-level settings
+podSettings:
+  # Change this to give pods more time to properly leave the cluster when not using persistent storage.
+  terminationGracePeriodSeconds: 30
+
+## Pod distruption budget
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+  # minAvailable: 2
+
+podManagementPolicy: OrderedReady
+updateStrategy:
+  type: OnDelete
+
+## Pod Security Context
+securityContext:
+  enabled: false
+  fsGroup: 999
+  runAsUser: 999
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Node tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # name:
+
+# Use host network for Cassandra pods
+# You must pass seed list into config.seeds property if set to true
+hostNetwork: false
+
+## Backup cronjob configuration
+## Ref: https://github.com/maorfr/cain
+backup:
+  enabled: false
+
+  # Schedule to run jobs. Must be in cron time format
+  # Ref: https://crontab.guru/
+  schedule:
+  - keyspace: keyspace1
+    cron: "0 7 * * *"
+  - keyspace: keyspace2
+    cron: "30 7 * * *"
+
+  annotations:
+    # Example for authorization to AWS S3 using kube2iam
+    # Can also be done using environment variables
+    iam.amazonaws.com/role: cain
+
+  image:
+    repository: maorfr/cain
+    tag: 0.6.0
+
+  # Additional arguments for cain
+  # Ref: https://github.com/maorfr/cain#usage
+  extraArgs: []
+
+  # Add additional environment variables
+  env:
+  # Example environment variable required for AWS credentials chain
+  - name: AWS_REGION
+    value: us-east-1
+
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 1
+    limits:
+      memory: 1Gi
+      cpu: 1
+
+  # Name of the secret containing the credentials of the service account used by GOOGLE_APPLICATION_CREDENTIALS, as a credentials.json file
+  # google:
+    # serviceAccountSecret:
+
+  # Destination to store the backup artifacts
+  # Supported cloud storage services: AWS S3, Minio S3, Azure Blob Storage, Google Cloud Storage
+  # Additional support can added. Visit this repository for details
+  # Ref: https://github.com/maorfr/skbn
+  destination: s3://bucket/cassandra
+
+## Cassandra exported configuration
+## ref: https://github.com/criteo/cassandra_exporter
+exporter:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+      # prometheus: default
+  image:
+    repo: criteord/cassandra_exporter
+    tag: 2.0.2
+  port: 5556
+  jvmOpts: ""
+  resources: {}
+    # limits:
+    #   cpu: 1
+    #   memory: 1Gi
+    # requests:
+    #   cpu: 1
+    #   memory: 1Gi
+
+extraVolumes: []
+extraVolumeMounts: []
+# extraVolumes and extraVolumeMounts allows you to mount other volumes
+# Example Use Case: mount ssl certificates
+# extraVolumes:
+#   - name: cas-certs
+#     secret:
+#       defaultMode: 420
+#       secretName: cas-certs
+# extraVolumeMounts:
+#   - name: cas-certs
+#     mountPath: /certs
+#     readOnly: true
+
+extraContainers: []
+## Additional containers to be added
+# extraContainers:
+# - name: cassandra-sidecar
+#   image: cassandra-sidecar:latest
+#   volumeMounts:
+#   - name: some-mount
+#     mountPath: /some/path

--- a/charts/mysql/.helmignore
+++ b/charts/mysql/.helmignore
@@ -1,0 +1,2 @@
+.git
+OWNERS

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+name: mysql
+version: 1.6.9
+appVersion: 5.7.30
+description: DEPRECATED - Fast, reliable, scalable, and easy to use open-source relational database
+  system.
+keywords:
+- mysql
+- database
+- sql
+home: https://www.mysql.com/
+icon: https://www.mysql.com/common/logos/logo-mysql-170x115.png
+sources:
+- https://github.com/kubernetes/charts
+- https://github.com/docker-library/mysql
+deprecated: true
+engine: gotpl

--- a/charts/mysql/README.md
+++ b/charts/mysql/README.md
@@ -1,0 +1,255 @@
+# ⚠️ Repo Archive Notice
+
+As of Nov 13, 2020, charts in this repo will no longer be updated.
+For more information, see the Helm Charts [Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
+
+# MySQL
+
+[MySQL](https://MySQL.org) is one of the most popular database servers in the world. Notable users include Wikipedia, Facebook and Google.
+
+## DEPRECATION NOTICE
+
+This chart is deprecated and no longer supported.
+
+## Introduction
+
+This chart bootstraps a single node MySQL deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.10+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/mysql
+```
+
+The command deploys MySQL on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+By default a random password will be generated for the root user. If you'd like to set your own password change the mysqlRootPassword
+in the values.yaml.
+
+You can retrieve your root password by running the following command. Make sure to replace [YOUR_RELEASE_NAME]:
+
+    printf $(printf '\%o' `kubectl get secret [YOUR_RELEASE_NAME]-mysql -o jsonpath="{.data.mysql-root-password[*]}"`)
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete --purge my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release completely.
+
+## Configuration
+
+The following table lists the configurable parameters of the MySQL chart and their default values.
+
+| Parameter                                    | Description                                                                                  | Default                                              |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `args`                                       | Additional arguments to pass to the MySQL container.                                         | `[]`                                                 |
+| `initContainer.resources`                    | initContainer resource requests/limits                                                       | Memory: `10Mi`, CPU: `10m`                           |
+| `image`                                      | `mysql` image repository.                                                                    | `mysql`                                              |
+| `imageTag`                                   | `mysql` image tag.                                                                           | `5.7.30`                                             |
+| `busybox.image`                              | `busybox` image repository.                                                                  | `busybox`                                            |
+| `busybox.tag`                                | `busybox` image tag.                                                                         | `1.32`                                               |
+| `testFramework.enabled`                      | `test-framework` switch.                                                                     | `true`                                               |
+| `testFramework.image`                        | `test-framework` image repository.                                                           | `bats/bats`                                          |
+| `testFramework.tag`                          | `test-framework` image tag.                                                                  | `1.2.1`                                              |
+| `testFramework.imagePullPolicy`              | `test-framework` image pull policy.                                                          | `IfNotPresent`                                       |
+| `testFramework.securityContext`              | `test-framework` securityContext                                                             | `{}`                                                 |
+| `imagePullPolicy`                            | Image pull policy                                                                            | `IfNotPresent`                                       |
+| `existingSecret`                             | Use Existing secret for Password details                                                     | `nil`                                                |
+| `extraVolumes`                               | Additional volumes as a string to be passed to the `tpl` function                            |                                                      |
+| `extraVolumeMounts`                          | Additional volumeMounts as a string to be passed to the `tpl` function                       |                                                      |
+| `extraInitContainers`                        | Additional init containers as a string to be passed to the `tpl` function                    |                                                      |
+| `extraEnvVars`                               | Additional environment variables as a string to be passed to the `tpl` function              |                                                      |
+| `mysqlRootPassword`                          | Password for the `root` user. Ignored if existing secret is provided                         | Random 10 characters                                 |
+| `mysqlUser`                                  | Username of new user to create.                                                              | `nil`                                                |
+| `mysqlPassword`                              | Password for the new user. Ignored if existing secret is provided                            | Random 10 characters                                 |
+| `mysqlDatabase`                              | Name for new database to create.                                                             | `nil`                                                |
+| `livenessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated                                                     | 30                                                   |
+| `livenessProbe.periodSeconds`                | How often to perform the probe                                                               | 10                                                   |
+| `livenessProbe.timeoutSeconds`               | When the probe times out                                                                     | 5                                                    |
+| `livenessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                    |
+| `livenessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                                                    |
+| `readinessProbe.initialDelaySeconds`         | Delay before readiness probe is initiated                                                    | 5                                                    |
+| `readinessProbe.periodSeconds`               | How often to perform the probe                                                               | 10                                                   |
+| `readinessProbe.timeoutSeconds`              | When the probe times out                                                                     | 1                                                    |
+| `readinessProbe.successThreshold`            | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                    |
+| `readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                                                    |
+| `schedulerName`                              | Name of the k8s scheduler (other than default)                                               | `nil`                                                |
+| `mysqlx.port.enabled`                        | Boolean to toggle a port for mysqlx `33060` protocol.                                        | false                                                |
+| `persistence.enabled`                        | Create a volume to store data                                                                | true                                                 |
+| `persistence.size`                           | Size of persistent volume claim                                                              | 8Gi RW                                               |
+| `persistence.storageClass`                   | Type of persistent volume claim                                                              | nil                                                  |
+| `persistence.accessMode`                     | ReadWriteOnce or ReadOnly                                                                    | ReadWriteOnce                                        |
+| `persistence.existingClaim`                  | Name of existing persistent volume                                                           | `nil`                                                |
+| `persistence.subPath`                        | Subdirectory of the volume to mount                                                          | `nil`                                                |
+| `persistence.annotations`                    | Persistent Volume annotations                                                                | {}                                                   |
+| `nodeSelector`                               | Node labels for pod assignment                                                               | {}                                                   |
+| `affinity`                                   | Affinity rules for pod assignment                                                            | {}                                                   |
+| `tolerations`                                | Pod taint tolerations for deployment                                                         | {}                                                   |
+| `metrics.enabled`                            | Start a side-car prometheus exporter                                                         | `false`                                              |
+| `metrics.image`                              | Exporter image                                                                               | `prom/mysqld-exporter`                               |
+| `metrics.imageTag`                           | Exporter image                                                                               | `v0.10.0`                                            |
+| `metrics.imagePullPolicy`                    | Exporter image pull policy                                                                   | `IfNotPresent`                                       |
+| `metrics.resources`                          | Exporter resource requests/limit                                                             | `nil`                                                |
+| `metrics.livenessProbe.initialDelaySeconds`  | Delay before metrics liveness probe is initiated                                             | 15                                                   |
+| `metrics.livenessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                                    |
+| `metrics.readinessProbe.initialDelaySeconds` | Delay before metrics readiness probe is initiated                                            | 5                                                    |
+| `metrics.readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | 1                                                    |
+| `metrics.flags`                              | Additional flags for the mysql exporter to use                                               | `[]`                                                 |
+| `metrics.serviceMonitor.enabled`             | Set this to `true` to create ServiceMonitor for Prometheus operator                          | `false`                                              |
+| `metrics.serviceMonitor.additionalLabels`    | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus        | `{}`                                                 |
+| `resources`                                  | CPU/Memory resource requests/limits                                                          | Memory: `256Mi`, CPU: `100m`                         |
+| `configurationFiles`                         | List of mysql configuration files                                                            | `nil`                                                |
+| `configurationFilesPath`                     | Path of mysql configuration files                                                            | `/etc/mysql/conf.d/`                                 |
+| `securityContext.enabled`                    | Enable security context (mysql pod)                                                          | `false`                                              |
+| `securityContext.fsGroup`                    | Group ID for the container (mysql pod)                                                       | 999                                                  |
+| `securityContext.runAsUser`                  | User ID for the container (mysql pod)                                                        | 999                                                  |
+| `service.annotations`                        | Kubernetes annotations for mysql                                                             | {}                                                   |
+| `service.type`                               | Kubernetes service type                                                                      | ClusterIP                                            |
+| `service.loadBalancerIP`                     | LoadBalancer service IP                                                                      | `""`                                                 |
+| `serviceAccount.create`                      | Specifies whether a ServiceAccount should be created                                         | `false`                                              |
+| `serviceAccount.name`                        | The name of the ServiceAccount to create                                                     | Generated using the mysql.fullname template          |
+| `ssl.enabled`                                | Setup and use SSL for MySQL connections                                                      | `false`                                              |
+| `ssl.secret`                                 | Name of the secret containing the SSL certificates                                           | mysql-ssl-certs                                      |
+| `ssl.certificates[0].name`                   | Name of the secret containing the SSL certificates                                           | `nil`                                                |
+| `ssl.certificates[0].ca`                     | CA certificate                                                                               | `nil`                                                |
+| `ssl.certificates[0].cert`                   | Server certificate (public key)                                                              | `nil`                                                |
+| `ssl.certificates[0].key`                    | Server key (private key)                                                                     | `nil`                                                |
+| `imagePullSecrets`                           | Name of Secret resource containing private registry credentials                              | `nil`                                                |
+| `initializationFiles`                        | List of SQL files which are run after the container started                                  | `nil`                                                |
+| `timezone`                                   | Container and mysqld timezone (TZ env)                                                       | `nil` (UTC depending on image)                       |
+| `podAnnotations`                             | Map of annotations to add to the pods                                                        | `{}`                                                 |
+| `podLabels`                                  | Map of labels to add to the pods                                                             | `{}`                                                 |
+| `priorityClassName`                          | Set pod priorityClassName                                                                    | `{}`                                                 |
+| `deploymentAnnotations`		       | Map of annotations for deployment							      | `{}`						     |
+| `strategy`                                   | Update strategy policy                                                                       | `{type: "Recreate"}`                                 |
+
+Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set mysqlRootPassword=secretpassword,mysqlUser=my-user,mysqlPassword=my-password,mysqlDatabase=my-database \
+    stable/mysql
+```
+
+The above command sets the MySQL `root` account password to `secretpassword`. Additionally it creates a standard database user named `my-user`, with the password `my-password`, who has access to a database named `my-database`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/mysql
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [MySQL](https://hub.docker.com/_/mysql/) image stores the MySQL data and configurations at the `/var/lib/mysql` path of the container.
+
+By default a PersistentVolumeClaim is created and mounted into that directory. In order to disable this functionality
+you can change the values.yaml to disable persistence and use an emptyDir instead.
+
+> *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+**Notice**: You may need to increase the value of `livenessProbe.initialDelaySeconds` when enabling persistence by using PersistentVolumeClaim from PersistentVolume with varying properties. Since its IO performance has impact on the database initialization performance. The default limit for database initialization is `60` seconds (`livenessProbe.initialDelaySeconds` + `livenessProbe.periodSeconds` * `livenessProbe.failureThreshold`). Once such initialization process takes more time than this limit, kubelet will restart the database container, which will interrupt database initialization then causing persisent data in an unusable state.
+
+## Custom MySQL configuration files
+
+The [MySQL](https://hub.docker.com/_/mysql/) image accepts custom configuration files at the path `/etc/mysql/conf.d`. If you want to use a customized MySQL configuration, you can create your alternative configuration files by passing the file contents on the `configurationFiles` attribute. Note that according to the MySQL documentation only files ending with `.cnf` are loaded.
+
+```yaml
+configurationFiles:
+  mysql.cnf: |-
+    [mysqld]
+    skip-host-cache
+    skip-name-resolve
+    sql-mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+  mysql_custom.cnf: |-
+    [mysqld]
+```
+
+## MySQL initialization files
+
+The [MySQL](https://hub.docker.com/_/mysql/) image accepts *.sh, *.sql and *.sql.gz files at the path `/docker-entrypoint-initdb.d`.
+These files are being run exactly once for container initialization and ignored on following container restarts.
+If you want to use initialization scripts, you can create initialization files by passing the file contents on the `initializationFiles` attribute.
+
+
+```yaml
+initializationFiles:
+  first-db.sql: |-
+    CREATE DATABASE IF NOT EXISTS first DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+  second-db.sql: |-
+    CREATE DATABASE IF NOT EXISTS second DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+```
+
+## SSL
+
+This chart supports configuring MySQL to use [encrypted connections](https://dev.mysql.com/doc/refman/5.7/en/encrypted-connections.html) with TLS/SSL certificates provided by the user. This is accomplished by storing the required Certificate Authority file, the server public key certificate, and the server private key as a Kubernetes secret. The SSL options for this chart support the following use cases:
+
+* Manage certificate secrets with helm
+* Manage certificate secrets outside of helm
+
+## Manage certificate secrets with helm
+
+Include your certificate data in the `ssl.certificates` section. For example:
+
+```
+ssl:
+  enabled: false
+  secret: mysql-ssl-certs
+  certificates:
+  - name: mysql-ssl-certs
+    ca: |-
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    cert: |-
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    key: |-
+      -----BEGIN RSA PRIVATE KEY-----
+      ...
+      -----END RSA PRIVATE KEY-----
+```
+
+> **Note**: Make sure your certificate data has the correct formatting in the values file.
+
+## Manage certificate secrets outside of helm
+
+1. Ensure the certificate secret exist before installation of this chart.
+2. Set the name of the certificate secret in `ssl.secret`.
+3. Make sure there are no entries underneath `ssl.certificates`.
+
+To manually create the certificate secret from local files you can execute:
+```
+kubectl create secret generic mysql-ssl-certs \
+  --from-file=ca.pem=./ssl/certificate-authority.pem \
+  --from-file=server-cert.pem=./ssl/server-public-key.pem \
+  --from-file=server-key.pem=./ssl/server-private-key.pem
+```
+> **Note**: `ca.pem`, `server-cert.pem`, and `server-key.pem` **must** be used as the key names in this generic secret.
+
+If you are using a certificate your configurationFiles must include the three ssl lines under [mysqld]
+
+```
+[mysqld]
+    ssl-ca=/ssl/ca.pem
+    ssl-cert=/ssl/server-cert.pem
+    ssl-key=/ssl/server-key.pem
+```

--- a/charts/mysql/templates/NOTES.txt
+++ b/charts/mysql/templates/NOTES.txt
@@ -1,0 +1,48 @@
+MySQL can be accessed via port 3306 on the following DNS name from within your cluster:
+{{ template "mysql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+{{- if .Values.mysqlx.port.enabled }}
+Connection to the X protocol of MySQL can be done via 33060 on the following DNS name from within your cluster:
+{{ template "mysql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end }}
+
+{{- if .Values.existingSecret }}
+If you have not already created the mysql password secret:
+
+   kubectl create secret generic {{ .Values.existingSecret }} --namespace {{ .Release.Namespace }} --from-file=./mysql-root-password --from-file=./mysql-password
+{{ else }}
+
+To get your root password run:
+
+    MYSQL_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mysql.fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode; echo)
+{{- end }}
+
+To connect to your database:
+
+1. Run an Ubuntu pod that you can use as a client:
+
+    kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il
+
+2. Install the mysql client:
+
+    $ apt-get update && apt-get install mysql-client -y
+
+3. Connect using the mysql cli, then provide your password:
+    $ mysql -h {{ template "mysql.fullname" . }} -p
+
+To connect to your database directly from outside the K8s cluster:
+    {{- if contains "NodePort" .Values.service.type }}
+    MYSQL_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+    MYSQL_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mysql.fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}')
+
+    {{- else if contains "ClusterIP" .Values.service.type }}
+    MYSQL_HOST=127.0.0.1
+    MYSQL_PORT={{ .Values.service.port }}
+
+    # Execute the following command to route the connection:
+    kubectl port-forward svc/{{ template "mysql.fullname" . }} {{ .Values.service.port }}
+
+    {{- end }}
+
+    mysql -h ${MYSQL_HOST} -P${MYSQL_PORT} -u root -p${MYSQL_ROOT_PASSWORD}
+    

--- a/charts/mysql/templates/_helpers.tpl
+++ b/charts/mysql/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mysql.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mysql.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "mysql.secretName" -}}
+{{ default (include "mysql.fullname" .) .Values.existingSecret }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mysql.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "mysql.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/mysql/templates/configurationFiles-configmap.yaml
+++ b/charts/mysql/templates/configurationFiles-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.configurationFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mysql.fullname" . }}-configuration
+  namespace: {{ .Release.Namespace }}
+data:
+{{- range $key, $val := .Values.configurationFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}

--- a/charts/mysql/templates/deployment.yaml
+++ b/charts/mysql/templates/deployment.yaml
@@ -1,0 +1,259 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+
+spec:
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
+  selector:
+    matchLabels:
+      app: {{ template "mysql.fullname" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "mysql.fullname" . }}
+        release: {{ .Release.Name }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+      serviceAccountName: {{ template "mysql.serviceAccountName" . }}
+      initContainers:
+      - name: "remove-lost-found"
+        image: "{{ .Values.busybox.image}}:{{ .Values.busybox.tag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+        resources:
+{{ toYaml .Values.initContainer.resources | indent 10 }}
+        command:  ["rm", "-fr", "/var/lib/mysql/lost+found"]
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+          {{- if .Values.persistence.subPath }}
+          subPath: {{ .Values.persistence.subPath }}
+          {{- end }}
+      {{- if .Values.extraInitContainers }}
+{{ tpl .Values.extraInitContainers . | indent 6 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ template "mysql.fullname" . }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+
+        {{- with .Values.args }}
+        args:
+        {{- range . }}
+          - {{ . | quote }}
+        {{- end }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        {{- if .Values.mysqlAllowEmptyPassword }}
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "true"
+        {{- end }}
+        {{- if not (and .Values.allowEmptyRootPassword (not .Values.mysqlRootPassword)) }}
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mysql.secretName" . }}
+              key: mysql-root-password
+              {{- if .Values.mysqlAllowEmptyPassword }}
+              optional: true
+              {{- end }}
+        {{- end }}
+        {{- if not (and .Values.allowEmptyRootPassword (not .Values.mysqlPassword)) }}
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mysql.secretName" . }}
+              key: mysql-password
+              {{- if or .Values.mysqlAllowEmptyPassword (empty .Values.mysqlUser) }}
+              optional: true
+              {{- end }}
+        {{- end }}
+        - name: MYSQL_USER
+          value: {{ default "" .Values.mysqlUser | quote }}
+        - name: MYSQL_DATABASE
+          value: {{ default "" .Values.mysqlDatabase | quote }}
+        {{- if .Values.timezone }}
+        - name: TZ
+          value: {{ .Values.timezone }}
+        {{- end }}
+        {{- if .Values.extraEnvVars }}
+{{ tpl .Values.extraEnvVars . | indent 8 }}
+        {{- end }}
+        ports:
+        - name: mysql
+          containerPort: 3306
+        {{- if .Values.mysqlx.port.enabled }}
+        - name: mysqlx
+          port: 33060
+        {{- end }}
+        livenessProbe:
+          exec:
+            command:
+            {{- if .Values.mysqlAllowEmptyPassword }}
+            - mysqladmin
+            - ping
+            {{- else }}
+            - sh
+            - -c
+            - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+            {{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        readinessProbe:
+          exec:
+            command:
+            {{- if .Values.mysqlAllowEmptyPassword }}
+            - mysqladmin
+            - ping
+            {{- else }}
+            - sh
+            - -c
+            - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+            {{- end }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+          {{- if .Values.persistence.subPath }}
+          subPath: {{ .Values.persistence.subPath }}
+          {{- end }}
+        {{- if .Values.configurationFiles }}
+        {{- range $key, $val := .Values.configurationFiles }}
+        - name: configurations
+          mountPath: {{ $.Values.configurationFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+        {{- end -}}
+        {{- end }}
+        {{- if .Values.initializationFiles }}
+        - name: migrations
+          mountPath: /docker-entrypoint-initdb.d
+        {{- end }}
+        {{- if .Values.ssl.enabled }}
+        - name: certificates
+          mountPath: /ssl
+        {{- end }}
+        {{- if .Values.extraVolumeMounts }}
+{{ tpl .Values.extraVolumeMounts . | indent 8 }}
+        {{- end }}
+      {{- if .Values.metrics.enabled }}
+      - name: metrics
+        image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
+        imagePullPolicy: {{ .Values.metrics.imagePullPolicy | quote }}
+        {{- if .Values.mysqlAllowEmptyPassword }}
+        command:
+        - 'sh'
+        - '-c'
+        - 'DATA_SOURCE_NAME="root@(localhost:3306)/" /bin/mysqld_exporter'
+        {{- else }}
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mysql.secretName" . }}
+              key: mysql-root-password
+        command:
+        - 'sh'
+        - '-c'
+        - 'DATA_SOURCE_NAME="root:$MYSQL_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter'
+        {{- end }}
+        {{- range $f := .Values.metrics.flags }}
+        - {{ $f | quote }}
+        {{- end }}
+        ports:
+        - name: metrics
+          containerPort: 9104
+        livenessProbe:
+          httpGet:
+            path: /
+            port: metrics
+          initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: metrics
+          initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.configurationFiles }}
+      - name: configurations
+        configMap:
+          name: {{ template "mysql.fullname" . }}-configuration
+      {{- end }}
+      {{- if .Values.initializationFiles }}
+      - name: migrations
+        configMap:
+          name: {{ template "mysql.fullname" . }}-initialization
+      {{- end }}
+      {{- if .Values.ssl.enabled }}
+      - name: certificates
+        secret:
+          secretName: {{ .Values.ssl.secret }}
+      {{- end }}
+      - name: data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "mysql.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}
+      {{- if .Values.extraVolumes }}
+{{ tpl .Values.extraVolumes . | indent 6 }}
+      {{- end }}

--- a/charts/mysql/templates/initializationFiles-configmap.yaml
+++ b/charts/mysql/templates/initializationFiles-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.initializationFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mysql.fullname" . }}-initialization
+  namespace: {{ .Release.Namespace }}
+data:
+{{- range $key, $val := .Values.initializationFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}

--- a/charts/mysql/templates/pvc.yaml
+++ b/charts/mysql/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.persistence.annotations  }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/mysql/templates/secrets.yaml
+++ b/charts/mysql/templates/secrets.yaml
@@ -1,0 +1,51 @@
+{{- if not .Values.existingSecret }}
+{{- if or (not .Values.allowEmptyRootPassword) (or .Values.mysqlRootPassword .Values.mysqlPassword) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if .Values.mysqlRootPassword }}
+  mysql-root-password:  {{ .Values.mysqlRootPassword | b64enc | quote }}
+  {{ else }}
+  {{ if not .Values.allowEmptyRootPassword }}
+  mysql-root-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  {{ end }}
+  {{ if .Values.mysqlPassword }}
+  mysql-password:  {{ .Values.mysqlPassword | b64enc | quote }}
+  {{ else }}
+  {{ if not .Values.allowEmptyRootPassword }}
+  mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  {{ end }}
+{{ end }}
+{{- if .Values.ssl.enabled }}
+{{ if .Values.ssl.certificates }}
+{{- range .Values.ssl.certificates }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "mysql.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+data:
+  ca.pem: {{ .ca | b64enc }}
+  server-cert.pem: {{ .cert | b64enc }}
+  server-key.pem: {{ .key | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/mysql/templates/serviceaccount.yaml
+++ b/charts/mysql/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "mysql.serviceAccountName" . }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/charts/mysql/templates/servicemonitor.yaml
+++ b/charts/mysql/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "mysql.fullname" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/mysql/templates/svc.yaml
+++ b/charts/mysql/templates/svc.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "mysql.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if and (.Values.metrics.enabled) (.Values.metrics.annotations) }}
+{{ toYaml .Values.metrics.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - name: mysql
+    port: {{ .Values.service.port }}
+    targetPort: mysql
+    {{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+  {{- if .Values.mysqlx.port.enabled }}
+  - name: mysqlx
+    port: 33060
+    targetPort: mysqlx
+    protocol: TCP
+  {{- end }}
+  {{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: 9104
+    targetPort: metrics
+  {{- end }}
+  selector:
+    app: {{ template "mysql.fullname" . }}

--- a/charts/mysql/templates/tests/test-configmap.yaml
+++ b/charts/mysql/templates/tests/test-configmap.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.testFramework.enabled  }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mysql.fullname" . }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+data:
+  run.sh: |-
+    {{- if .Values.ssl.enabled | and .Values.mysqlRootPassword }}
+    @test "Testing SSL MySQL Connection" {
+      mysql --host={{ template "mysql.fullname" . }} --port={{ .Values.service.port | default "3306" }} --ssl-cert=/ssl/server-cert.pem --ssl-key=ssl/server-key.pem -u root -p{{ .Values.mysqlRootPassword }}
+    }
+    {{- else if .Values.mysqlRootPassword }}
+    @test "Testing MySQL Connection" {
+      mysql --host={{ template "mysql.fullname" . }} --port={{ .Values.service.port | default "3306" }} -u root -p{{ .Values.mysqlRootPassword }}
+    }
+    {{- end }}
+{{- end }}

--- a/charts/mysql/templates/tests/test.yaml
+++ b/charts/mysql/templates/tests/test.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.testFramework.enabled  }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "mysql.fullname" . }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mysql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  {{- if .Values.testFramework.securityContext }}
+  securityContext: {{ toYaml .Values.testFramework.securityContext | nindent 4 }}
+  {{- end }}
+  {{- if .Values.imagePullSecrets }}
+  imagePullSecrets:
+  {{- range .Values.imagePullSecrets }}
+    - name: {{ . }}
+  {{- end}}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+  affinity:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  containers:
+    - name: {{ .Release.Name }}-test
+      image: "{{ .Values.testFramework.image }}:{{ .Values.testFramework.tag }}"
+      imagePullPolicy: "{{ .Values.testFramework.imagePullPolicy}}"
+      command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+      {{- if .Values.ssl.enabled }}
+      - name: certificates
+        mountPath: /ssl
+      {{- end }}
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "mysql.fullname" . }}-test
+  {{- if .Values.ssl.enabled }}
+  - name: certificates
+    secret:
+      secretName: {{ .Values.ssl.secret }}
+  {{- end }}
+  restartPolicy: Never
+{{- end }}

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -1,0 +1,246 @@
+## mysql image version
+## ref: https://hub.docker.com/r/library/mysql/tags/
+##
+image: "mysql"
+imageTag: "5.7.30"
+
+strategy:
+  type: Recreate
+
+busybox:
+  image: "busybox"
+  tag: "1.32"
+
+testFramework:
+  enabled: true
+  image: "bats/bats"
+  tag: "1.2.1"
+  imagePullPolicy: IfNotPresent
+  securityContext: {}
+
+## Specify password for root user
+##
+## Default: random 10 character string
+# mysqlRootPassword: testing
+
+## Create a database user
+##
+# mysqlUser:
+## Default: random 10 character string
+# mysqlPassword:
+
+## Allow unauthenticated access, uncomment to enable
+##
+# mysqlAllowEmptyPassword: true
+
+## Create a database
+##
+# mysqlDatabase:
+
+## Specify an imagePullPolicy (Required)
+## It's recommended to change this to 'Always' if the image tag is 'latest'
+## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+##
+imagePullPolicy: IfNotPresent
+
+## Additionnal arguments that are passed to the MySQL container.
+## For example use --default-authentication-plugin=mysql_native_password if older clients need to
+## connect to a MySQL 8 instance.
+args: []
+
+extraVolumes: |
+  # - name: extras
+  #   emptyDir: {}
+
+extraVolumeMounts: |
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
+extraInitContainers: |
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']
+
+## A string to add extra environment variables
+# extraEnvVars: |
+#   - name: EXTRA_VAR
+#     value: "extra"
+
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# imagePullSecrets:
+  # - name: myRegistryKeySecretName
+
+## Node selector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+## Affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+
+## Persist data to a persistent volume
+persistence:
+  enabled: true
+  ## database data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 8Gi
+  annotations: {}
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## Security context
+securityContext:
+  enabled: false
+  runAsUser: 999
+  fsGroup: 999
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 100m
+
+# Custom mysql configuration files path
+configurationFilesPath: /etc/mysql/conf.d/
+
+# Custom mysql configuration files used to override default mysql settings
+configurationFiles: {}
+#  mysql.cnf: |-
+#    [mysqld]
+#    skip-name-resolve
+#    ssl-ca=/ssl/ca.pem
+#    ssl-cert=/ssl/server-cert.pem
+#    ssl-key=/ssl/server-key.pem
+
+# Custom mysql init SQL files used to initialize the database
+initializationFiles: {}
+#  first-db.sql: |-
+#    CREATE DATABASE IF NOT EXISTS first DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+#  second-db.sql: |-
+#    CREATE DATABASE IF NOT EXISTS second DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+
+# To enaable the mysql X Protocol's port
+# .. will expose the port 33060
+# .. Note the X Plugin needs installation
+# ref: https://dev.mysql.com/doc/refman/8.0/en/x-plugin-checking-installation.html
+mysqlx:
+  port:
+    enabled: false
+
+metrics:
+  enabled: false
+  image: prom/mysqld-exporter
+  imageTag: v0.10.0
+  imagePullPolicy: IfNotPresent
+  resources: {}
+  annotations: {}
+    # prometheus.io/scrape: "true"
+    # prometheus.io/port: "9104"
+  livenessProbe:
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+  readinessProbe:
+    initialDelaySeconds: 5
+    timeoutSeconds: 1
+  flags: []
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+
+## Configure the service
+## ref: http://kubernetes.io/docs/user-guide/services/
+service:
+  annotations: {}
+  ## Specify a service type
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types
+  type: ClusterIP
+  port: 3306
+  # nodePort: 32000
+  # loadBalancerIP:
+
+## Pods Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  ##
+  create: false
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the mariadb.fullname template
+  # name:
+
+ssl:
+  enabled: false
+  secret: mysql-ssl-certs
+  certificates:
+#  - name: mysql-ssl-certs
+#    ca: |-
+#      -----BEGIN CERTIFICATE-----
+#      ...
+#      -----END CERTIFICATE-----
+#    cert: |-
+#      -----BEGIN CERTIFICATE-----
+#      ...
+#      -----END CERTIFICATE-----
+#    key: |-
+#      -----BEGIN RSA PRIVATE KEY-----
+#      ...
+#      -----END RSA PRIVATE KEY-----
+
+## Populates the 'TZ' system timezone environment variable
+## ref: https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html
+##
+## Default: nil (mysql will use image's default timezone, normally UTC)
+## Example: 'Australia/Sydney'
+# timezone:
+
+# Deployment Annotations
+deploymentAnnotations: {}
+
+# To be added to the database server pod(s)
+podAnnotations: {}
+podLabels: {}
+
+## Set pod priorityClassName
+# priorityClassName: {}
+
+
+## Init container resources defaults
+initContainer:
+  resources:
+    requests:
+      memory: 10Mi
+      cpu: 10m


### PR DESCRIPTION
This PR removes dependencies from remote helm repositories for Cassandra and MySQL, so we could modify them in a future PR to add the missing support for Helm Hooks which is required to fix the startup problem described in #6. This is the first of two PR, designed with the goal of simplifying future development

First, we copied into the current repository the MySQL and Cassandra helm chart from deprecated https://github.com/helm/charts

```
cd ..
rm -rf charts
git clone https://github.com/helm/charts
cp -r charts/stable/mysql cadence-helm-chart/charts/
cp -r charts/incubator/cassandra cadence-helm-chart/charts/
```

Then we updated the `requirements.yml` to use the local dependencies, including updating Cassandra to a slightly more recent helm chart.

Eventually, we added a CI pipeline that run a diff between the fork of the helm chart we had locally and the original helm charts. In the next PR we'll remove such a pipeline and fix the charts
